### PR TITLE
Bump cookiecutter template to eb3288

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "373c1399cafca5c5807e32ff96d16e1e59b4d043",
+  "commit": "eb3288712d3ec2451cd3eee3af7e4af88ca37048",
   "checkout": null,
   "context": {
     "cookiecutter": {


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/eb3288
