### PR TITLE
Bump cookiecutter template to 25c36c

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "15dd517e9d8aebb087e1f0387cf726a8164e7913",
+  "commit": "25c36c49159f9309b55815b6606a8dfb66228858",
   "checkout": null,
   "context": {
     "cookiecutter": {

--- a/.github/workflows/renovatebot.yml
+++ b/.github/workflows/renovatebot.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run renovatebot
-        uses: renovatebot/github-action@v40.1.9
+        uses: renovatebot/github-action@v40.1.11
         env:
           RENOVATE_GIT_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           RENOVATE_REPOSITORIES: "robert-koch-institut/mex-editor"


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/25c36c
