### PR TITLE
Bump cookiecutter template to d4069c

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "20d79c1e1bde360a5767847f79ad70b683a5d88f",
+  "commit": "d4069ccba84c939a50651947e12cf36e2e9ce1aa",
   "checkout": null,
   "context": {
     "cookiecutter": {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,12 +85,48 @@ jobs:
   containerize:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: release
     steps:
-      - name: Build, tag and push docker image to ghcr
-        uses: GlueOps/github-actions-build-push-containers@v0.4.5
+      - name: Checkout repo
+        uses: actions/checkout@v4
         with:
-          tags: "${{ github.sha }},${{ needs.release.outputs.tag }},latest"
+          fetch-depth: 1
+
+      - name: Cache requirements
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-requirements
+        with:
+          path: ~/.cache/pip
+          key: ${{ env.cache-name }}-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ env.cache-name }}-
+
+      - name: Setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+
+      - name: Install requirements
+        run: make setup
+
+      - name: Generate locked requirements.txt
+        run: |
+          pdm export --self --output locked-requirements.txt --no-hashes --without dev
+
+      - name: 'Login to GitHub Container Registry'
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{github.actor}}
+          password: ${{secrets.GITHUB_TOKEN}}
+
+      - name: 'Build Inventory Image'
+        run: |
+          docker build . 
+          --tag ghcr.io/robert-koch-institut/mex-editor:latest
+          --tag ghcr.io/robert-koch-institut/mex-editor:${{ github.sha }}
+          --tag ghcr.io/robert-koch-institut/mex-editor:${{ needs.release.outputs.tag }}
+          docker push ghcr.io/robert-koch-institut/mex-editor:latest
 
   distribute:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN adduser \
 
 COPY . .
 
-RUN --mount=type=cache,target=/root/.cache/pip pip install .
+RUN --mount=type=cache,target=/root/.cache/pip pip install -r locked-requirements.txt --no-deps
 
 USER mex
 


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/d4069c

# Conflicts

```diff a/pyproject.toml b/pyproject.toml	(rejected hunks)
@@ -9,14 +9,14 @@ urls = { Repository = "https://github.com/robert-koch-institut/mex-editor" }
 requires-python = "<3.13,>=3.11"
 dependencies = []
 optional-dependencies.dev = [
-    "ipdb==0.13.13",
-    "mypy==1.11.0",
-    "pytest-cov==5.0.0",
-    "pytest-random-order==1.1.1",
-    "pytest-xdist==3.6.1",
-    "pytest==8.3.1",
-    "ruff==0.5.4",
-    "sphinx==7.4.5",
+    "ipdb>=0.13.13,<1",
+    "mypy>=1.11.0,<2",
+    "pytest-cov>=5.0.0,<6",
+    "pytest-random-order>=1.1.1,<2",
+    "pytest-xdist>=3.6.1,<4",
+    "pytest>=8.3.1,<9",
+    "ruff>=0.5.4,<1",
+    "sphinx>=7.4.5,<8",
 ]
 
 [project.scripts]
```
