### PR TITLE
feature/mx-1768 prepare url search params

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -85,7 +85,7 @@ jobs:
           MEX_BACKEND_API_KEY: ${{ secrets.MEX_BACKEND_API_KEY }}
           MEX_IDENTITY_PROVIDER: backend
         run: |
-          pdm run editor run &
+          pdm run editor &
           sleep 30 &&
           curl --connect-timeout 1 --max-time 20 --retry 10 --retry-delay 1 http://localhost:8000/_system/check &&
           curl --connect-timeout 1 --max-time 20 --retry 10 --retry-delay 1 http://localhost:8080/v0/_system/check &&

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
-- update mex-common to version 0.48.0
+- update mex-common to version 0.49.3
+- BREAKING: you must start the local dev mode simply with `pdm run editor` (no 2nd run)
+- simplify some styles
 
 ### Deprecated
 
@@ -22,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - remove EditorIdentityProvider enum in favor of mex-common enum
 
 ### Fixed
+
+- decorate state handlers with `@rx.event` to satisfy new reflex versions
+- explicitly define cache strategies for vars with `@rx.var(cache=False)`
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - update mex-common to version 0.49.3
 - BREAKING: you must start the local dev mode simply with `pdm run editor` (no 2nd run)
+- BREAKING: rename postfix_badge to render_badge (for consistency)
 - simplify some styles
 
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -105,4 +105,4 @@ components of the MEx project are open-sourced under the same license as well.
 
 ### Editor
 
-- `pdm run editor run` starts the editor service
+- `pdm run editor` starts the editor service

--- a/mex/editor/components.py
+++ b/mex/editor/components.py
@@ -41,8 +41,8 @@ def render_text(value: EditorValue) -> rx.Component:
     )
 
 
-def postfix_badge(value: EditorValue) -> rx.Component:
-    """Render a generic badge after an editor value."""
+def render_badge(value: EditorValue) -> rx.Component:
+    """Render a generic badge for an editor value."""
     return rx.badge(
         value.badge,
         radius="full",
@@ -61,7 +61,7 @@ def render_value(value: EditorValue) -> rx.Component:
         ),
         rx.cond(
             value.badge,
-            postfix_badge(value),
+            render_badge(value),
         ),
         spacing="1",
     )

--- a/mex/editor/edit/main.py
+++ b/mex/editor/edit/main.py
@@ -17,11 +17,7 @@ def editor_value_switch(
     """Return a switch for toggling subtractive rules."""
     return rx.switch(
         checked=value.enabled,
-        on_change=lambda enabled: cast(EditState, EditState).toggle_field_value(
-            field_name,
-            value,
-            enabled,
-        ),
+        on_change=cast(EditState, EditState).toggle_field_value(field_name, value),
         custom_attrs={"data-testid": f"switch-{field_name}-{primary_source}-{index}"},
     )
 
@@ -53,10 +49,8 @@ def primary_source_switch(
     """Return a switch for toggling preventive rules."""
     return rx.switch(
         checked=model.enabled,
-        on_change=lambda enabled: cast(EditState, EditState).toggle_primary_source(
-            field_name,
-            cast(str, model.name.href),
-            enabled,
+        on_change=cast(EditState, EditState).toggle_primary_source(
+            field_name, model.name.href
         ),
         custom_attrs={"data-testid": f"switch-{field_name}-{model.identifier}"},
     )

--- a/mex/editor/edit/state.py
+++ b/mex/editor/edit/state.py
@@ -31,6 +31,7 @@ class EditState(State):
     stem_type: str | None = None
     editor_fields: list[str] = []
 
+    @rx.event
     def refresh(self) -> Generator[EventSpec | None, None, None]:
         """Refresh the edit page."""
         self.reset()
@@ -82,6 +83,7 @@ class EditState(State):
             preventive=rule_set.preventive,
         )
 
+    @rx.event
     def submit_rule_set(self) -> Generator[EventSpec | None, None, None]:
         """Convert the fields to a rule set and submit it to the backend."""
         if (stem_type := self.stem_type) is None:
@@ -121,13 +123,25 @@ class EditState(State):
         msg = f"field not found: {field_name}"
         raise ValueError(msg)
 
-    def toggle_primary_source(self, field_name: str, href: str, enabled: bool) -> None:
+    @rx.event
+    def toggle_primary_source(
+        self,
+        field_name: str,
+        href: str | None,
+        enabled: bool,
+    ) -> None:
         """Toggle the `enabled` flag of a primary source."""
         for primary_source in self._get_primary_sources_by_field_name(field_name):
             if primary_source.name.href == href:
                 primary_source.enabled = enabled
 
-    def toggle_field_value(self, field_name: str, value: object, enabled: bool) -> None:
+    @rx.event
+    def toggle_field_value(
+        self,
+        field_name: str,
+        value: EditorValue,
+        enabled: bool,
+    ) -> None:
         """Toggle the `enabled` flag of a field value."""
         for primary_source in self._get_primary_sources_by_field_name(field_name):
             for editor_value in primary_source.editor_values:

--- a/mex/editor/main.py
+++ b/mex/editor/main.py
@@ -1,0 +1,7 @@
+import typer
+from reflex.reflex import run
+
+
+def main() -> None:  # pragma: no cover
+    """Start the editor service."""
+    typer.run(run)

--- a/mex/editor/merge/main.py
+++ b/mex/editor/merge/main.py
@@ -9,6 +9,5 @@ def index() -> rx.Component:
         rx.heading(
             "Merge",
             custom_attrs={"data-testid": "merge-heading"},
-            style={"margin": "1em 0"},
         )
     )

--- a/mex/editor/search/main.py
+++ b/mex/editor/search/main.py
@@ -105,7 +105,7 @@ def pagination() -> rx.Component:
     """Render pagination for navigating search results."""
     return rx.center(
         rx.button(
-            rx.text("Previous", weight="bold"),
+            rx.text("Previous"),
             on_click=SearchState.go_to_previous_page,
             disabled=SearchState.disable_previous_page,
             spacing="2",
@@ -121,7 +121,7 @@ def pagination() -> rx.Component:
             custom_attrs={"data-testid": "pagination-page-select"},
         ),
         rx.button(
-            rx.text("Next", weight="bold"),
+            rx.text("Next"),
             on_click=SearchState.go_to_next_page,
             disabled=SearchState.disable_next_page,
             spacing="2",

--- a/mex/editor/search/state.py
+++ b/mex/editor/search/state.py
@@ -23,37 +23,40 @@ class SearchState(State):
     current_page: int = 1
     limit: int = 50
 
-    @rx.var
+    @rx.var(cache=False)
     def disable_previous_page(self) -> bool:
         """Disable the 'Previous' button if on the first page."""
         return self.current_page <= 1
 
-    @rx.var
+    @rx.var(cache=False)
     def disable_next_page(self) -> bool:
         """Disable the 'Next' button if on the last page."""
         max_page = math.ceil(self.total / self.limit)
         return self.current_page >= max_page
 
-    @rx.var
+    @rx.var(cache=False)
     def current_results_length(self) -> int:
         """Return the number of current search results."""
         return len(self.results)
 
-    @rx.var
+    @rx.var(cache=False)
     def total_pages(self) -> list[str]:
         """Return a list of total pages based on the number of results."""
         return [f"{i + 1}" for i in range(math.ceil(self.total / self.limit))]
 
+    @rx.event
     def set_query_string(self, value: str) -> Generator[EventSpec | None, None, None]:
         """Set the query string and refresh the results."""
         self.query_string = value
         return self.search()
 
+    @rx.event
     def set_entity_type(self, value, index) -> Generator[EventSpec | None, None, None]:
         """Set the entity type for filtering and refresh the results."""
         self.entity_types[index] = value
         return self.search()
 
+    @rx.event
     def set_page(
         self, page_number: str | int
     ) -> Generator[EventSpec | None, None, None]:
@@ -61,14 +64,17 @@ class SearchState(State):
         self.current_page = int(page_number)
         return self.search()
 
+    @rx.event
     def go_to_previous_page(self) -> Generator[EventSpec | None, None, None]:
         """Navigate to the previous page."""
         return self.set_page(self.current_page - 1)
 
+    @rx.event
     def go_to_next_page(self) -> Generator[EventSpec | None, None, None]:
         """Navigate to the next page."""
         return self.set_page(self.current_page + 1)
 
+    @rx.event
     def search(self) -> Generator[EventSpec | None, None, None]:
         """Refresh the search results."""
         # TODO(ND): use the user auth for backend requests (stop-gap MX-1616)
@@ -91,6 +97,7 @@ class SearchState(State):
         self.results = transform_models_to_results(response.items)
         self.total = response.total
 
+    @rx.event
     def refresh(self) -> Generator[EventSpec | None, None, None]:
         """Refresh the search page."""
         self.reset()

--- a/mex/editor/state.py
+++ b/mex/editor/state.py
@@ -16,11 +16,13 @@ class State(rx.State):
         NavItem(title="Merge", href_template=r"/merge/"),
     ]
 
+    @rx.event
     def logout(self) -> EventSpec:
         """Log out a user."""
         self.reset()
         return rx.redirect("/")
 
+    @rx.event
     def check_login(self) -> EventSpec | None:
         """Check if a user is logged in."""
         if self.user is None:
@@ -28,6 +30,7 @@ class State(rx.State):
             return rx.redirect("/login")
         return None
 
+    @rx.event
     def load_nav(self) -> None:
         """Event hook for updating the navigation on page loads."""
         self.item_id = self.router.page.params.get("item_id")

--- a/mex/mex.py
+++ b/mex/mex.py
@@ -15,7 +15,10 @@ from mex.editor.state import State
 
 app = rx.App(
     html_lang="en",
-    theme=themes.theme(accent_color="blue"),
+    theme=themes.theme(
+        accent_color="blue",
+        has_background=False,
+    ),
 )
 app.add_page(
     edit_index,

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:a5f76fd4c8be5e3d9a6e61c87da043bb60baaf531790e0ced41fbba4cdd7e107"
+content_hash = "sha256:9e9ccdd67c6c891618c17b0e14e7eff382c6577394a766edb78b33de13f98ec2"
 
 [[metadata.targets]]
 requires_python = "==3.11.*"
@@ -768,11 +768,11 @@ files = [
 
 [[package]]
 name = "mex-common"
-version = "0.48.0"
+version = "0.49.3"
 requires_python = ">=3.11,<3.13"
 git = "https://github.com/robert-koch-institut/mex-common.git"
-ref = "0.48.0"
-revision = "9a917770bf36f04e5fe62cdb7b0ca36ee68d143c"
+ref = "0.49.3"
+revision = "408511b12507ab374dda937600875359c131b903"
 summary = "Common library for MEx python projects."
 groups = ["default"]
 dependencies = [
@@ -780,7 +780,7 @@ dependencies = [
     "click<9,>=8",
     "langdetect<2,>=1",
     "ldap3<3,>=2",
-    "mex-model @ git+https://github.com/robert-koch-institut/mex-model.git@3.4.0",
+    "mex-model @ git+https://github.com/robert-koch-institut/mex-model.git@3.5.1",
     "numpy<3,>=2",
     "pandas<3,>=2",
     "pyarrow<20,>=19",
@@ -792,11 +792,11 @@ dependencies = [
 
 [[package]]
 name = "mex-model"
-version = "3.4.0"
+version = "3.5.1"
 requires_python = ">=3.11,<3.13"
 git = "https://github.com/robert-koch-institut/mex-model.git"
-ref = "3.4.0"
-revision = "08d161d40c659a69c52af76b654db41f49616a24"
+ref = "3.5.1"
+revision = "6216b062053c4de6c25875d7e72b0f683350f7c3"
 summary = "JSON schema files defining the MEx metadata model."
 groups = ["default"]
 
@@ -964,22 +964,22 @@ files = [
 
 [[package]]
 name = "playwright"
-version = "1.49.1"
+version = "1.50.0"
 requires_python = ">=3.9"
 summary = "A high-level API to automate web browsers"
 groups = ["dev"]
 dependencies = [
-    "greenlet==3.1.1",
-    "pyee==12.0.0",
+    "greenlet<4.0.0,>=3.1.1",
+    "pyee<13,>=12",
 ]
 files = [
-    {file = "playwright-1.49.1-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:1041ffb45a0d0bc44d698d3a5aa3ac4b67c9bd03540da43a0b70616ad52592b8"},
-    {file = "playwright-1.49.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:9f38ed3d0c1f4e0a6d1c92e73dd9a61f8855133249d6f0cec28648d38a7137be"},
-    {file = "playwright-1.49.1-py3-none-macosx_11_0_universal2.whl", hash = "sha256:3be48c6d26dc819ca0a26567c1ae36a980a0303dcd4249feb6f59e115aaddfb8"},
-    {file = "playwright-1.49.1-py3-none-manylinux1_x86_64.whl", hash = "sha256:753ca90ee31b4b03d165cfd36e477309ebf2b4381953f2a982ff612d85b147d2"},
-    {file = "playwright-1.49.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cd9bc8dab37aa25198a01f555f0a2e2c3813fe200fef018ac34dfe86b34994b9"},
-    {file = "playwright-1.49.1-py3-none-win32.whl", hash = "sha256:43b304be67f096058e587dac453ece550eff87b8fbed28de30f4f022cc1745bb"},
-    {file = "playwright-1.49.1-py3-none-win_amd64.whl", hash = "sha256:47b23cb346283278f5b4d1e1990bcb6d6302f80c0aa0ca93dd0601a1400191df"},
+    {file = "playwright-1.50.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:f36d754a6c5bd9bf7f14e8f57a2aea6fd08f39ca4c8476481b9c83e299531148"},
+    {file = "playwright-1.50.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:40f274384591dfd27f2b014596250b2250c843ed1f7f4ef5d2960ecb91b4961e"},
+    {file = "playwright-1.50.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:9922ef9bcd316995f01e220acffd2d37a463b4ad10fd73e388add03841dfa230"},
+    {file = "playwright-1.50.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:8fc628c492d12b13d1f347137b2ac6c04f98197ff0985ef0403a9a9ee0d39131"},
+    {file = "playwright-1.50.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffcff35f72db2689a79007aee78f1b0621a22e6e3d6c1f58aaa9ac805bf4497c"},
+    {file = "playwright-1.50.0-py3-none-win32.whl", hash = "sha256:3b906f4d351260016a8c5cc1e003bb341651ae682f62213b50168ed581c7558a"},
+    {file = "playwright-1.50.0-py3-none-win_amd64.whl", hash = "sha256:1859423da82de631704d5e3d88602d755462b0906824c1debe140979397d2e8d"},
 ]
 
 [[package]]
@@ -1146,7 +1146,7 @@ files = [
 
 [[package]]
 name = "pyee"
-version = "12.0.0"
+version = "12.1.1"
 requires_python = ">=3.8"
 summary = "A rough port of Node.js's EventEmitter to Python with a few tricks of its own"
 groups = ["dev"]
@@ -1154,8 +1154,8 @@ dependencies = [
     "typing-extensions",
 ]
 files = [
-    {file = "pyee-12.0.0-py3-none-any.whl", hash = "sha256:7b14b74320600049ccc7d0e0b1becd3b4bd0a03c745758225e31a59f4095c990"},
-    {file = "pyee-12.0.0.tar.gz", hash = "sha256:c480603f4aa2927d4766eb41fa82793fe60a82cbfdb8d688e0d08c55a534e145"},
+    {file = "pyee-12.1.1-py3-none-any.whl", hash = "sha256:18a19c650556bb6b32b406d7f017c8f513aceed1ef7ca618fb65de7bd2d347ef"},
+    {file = "pyee-12.1.1.tar.gz", hash = "sha256:bbc33c09e2ff827f74191e3e5bbc6be7da02f627b7ec30d86f5ce1a6fb2424a3"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.11,<3.12"
 dependencies = [
     "babel>=2,<3",
     "fastapi>=0.115,<1",
-    "mex-common @ git+https://github.com/robert-koch-institut/mex-common.git@0.48.0",
+    "mex-common @ git+https://github.com/robert-koch-institut/mex-common.git@0.49.3",
     "pydantic>=2,<3",
     "pytz>=2024,<2025",
     "pyyaml>=6,<7",
@@ -18,6 +18,7 @@ dependencies = [
     "reflex>=0.6,<1",
     "requests>=2,<3",
     "starlette>=0.41,<1",
+    "typer>=0.15,<1",
     "uvicorn>=0.32,<1",
 ]
 optional-dependencies.dev = [
@@ -34,7 +35,7 @@ optional-dependencies.dev = [
 ]
 
 [project.scripts]
-editor = "reflex.reflex:cli"
+editor = "mex.editor.main:main"
 
 [tool.cruft]
 template = "https://github.com/robert-koch-institut/mex-template"


### PR DESCRIPTION
### PR Context

- prep for https://github.com/robert-koch-institut/mex-editor/pull/241

### Changes

- update mex-common to version 0.49.3
- BREAKING: you must start the local dev mode simply with `pdm run editor` (no 2nd run)
- BREAKING: rename postfix_badge to render_badge (for consistency)
- simplify some styles

### Fixed

- decorate state handlers with `@rx.event` to satisfy new reflex versions
- explicitly define cache strategies for vars with `@rx.var(cache=False)`
