### PR TITLE
Bump cookiecutter template to 8bdad0

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "71224cdf6b9828906fd1591f7572bdb12f8f9408",
+  "commit": "8bdad06a5eca52607f046b75cb0cdd9d7ab4912e",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -8,7 +8,7 @@
       "short_summary": "Metadata editor web application.",
       "long_summary": "The `mex-editor` is a browser application that allows creating and editing rules to non-destructively manipulate metadata. This can be used to enrich data with manual input or insert new data from scratch.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "71224cdf6b9828906fd1591f7572bdb12f8f9408"
+      "_commit": "8bdad06a5eca52607f046b75cb0cdd9d7ab4912e"
     }
   },
   "directory": null


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/8bdad0
