### PR TITLE
feature/mx-1767 show editor and backend versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          ref: ${{ needs.release.outputs.tag }}
 
       - name: Cache requirements
         uses: actions/cache@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- show mex-editor and mex-backend versions when hovering over logo
+
 ### Changes
 
 ### Deprecated

--- a/mex/editor/api/main.py
+++ b/mex/editor/api/main.py
@@ -1,3 +1,5 @@
+from importlib.metadata import version
+
 from pydantic import BaseModel
 
 
@@ -5,8 +7,9 @@ class SystemStatus(BaseModel):
     """Response model for system status check."""
 
     status: str
+    version: str
 
 
 def check_system_status() -> SystemStatus:
-    """Check that the backend server is healthy and responsive."""
-    return SystemStatus(status="ok")
+    """Check that the editor server is healthy and responsive."""
+    return SystemStatus(status="ok", version=version("mex-editor"))

--- a/mex/editor/layout.py
+++ b/mex/editor/layout.py
@@ -50,17 +50,28 @@ def nav_link(item: NavItem) -> rx.Component:
 
 def app_logo() -> rx.Component:
     """Return the app logo with icon and label."""
-    return rx.hstack(
-        rx.icon(
-            "circuit-board",
-            size=28,
+    return rx.hover_card.root(
+        rx.hover_card.trigger(
+            rx.hstack(
+                rx.icon(
+                    "circuit-board",
+                    size=28,
+                ),
+                rx.heading(
+                    "MEx Editor",
+                    weight="medium",
+                    style={"userSelect": "none"},
+                ),
+                custom_attrs={"data-testid": "app-logo"},
+            )
         ),
-        rx.heading(
-            "MEx Editor",
-            weight="medium",
-            style={"userSelect": "none"},
+        rx.hover_card.content(
+            rx.vstack(
+                rx.code(f"mex-editor=={State.editor_version}", variant="outline"),
+                rx.code(f"mex-backend=={State.backend_version}", variant="outline"),
+            ),
         ),
-        custom_attrs={"data-testid": "app-logo"},
+        open_delay=500,
     )
 
 

--- a/mex/editor/state.py
+++ b/mex/editor/state.py
@@ -1,8 +1,10 @@
+from importlib.metadata import version
 from urllib.parse import urlencode
 
 import reflex as rx
 from reflex.event import EventSpec
 
+from mex.common.backend_api.connector import BackendApiConnector
 from mex.common.models import MEX_PRIMARY_SOURCE_STABLE_TARGET_ID
 from mex.editor.models import NavItem, User
 
@@ -86,3 +88,16 @@ class State(rx.State):
                 nav_item.underline = "always"
             else:
                 nav_item.underline = "none"
+
+    @rx.var(cache=True)
+    def editor_version(self) -> str:
+        """Return the version of mex-editor."""
+        return version("mex-editor")
+
+    @rx.var(cache=True)
+    def backend_version(self) -> str:
+        """Return the version of mex-backend."""
+        connector = BackendApiConnector.get()
+        # TODO(ND): use proper connector method when available (stop-gap MX-1762)
+        response = connector.request("GET", "_system/check")
+        return str(response.get("version", "N/A"))

--- a/tests/api/test_main.py
+++ b/tests/api/test_main.py
@@ -1,7 +1,9 @@
 from fastapi.testclient import TestClient
 
+from mex.common.testing import Joker
+
 
 def test_health_check(client: TestClient) -> None:
     response = client.get("/_system/check")
     assert response.status_code == 200, response.text
-    assert response.json() == {"status": "ok"}
+    assert response.json() == {"status": "ok", "version": Joker()}


### PR DESCRIPTION
### PR Context
I decided to show the versions as a tooltip to the logo. The logo component is used on the main page as well as the login, so you can also get to the version without logging in.

### Added
- show mex-editor and mex-backend versions when hovering over logo
