### PR TITLE
feature/mx-1829 add search button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes
 
 - apply ruff TC006 by quoting type expressions in `typing.cast` calls
+- search initiation now requires hitting enter or clicking the search button
 
 ### Deprecated
 

--- a/mex/editor/aux_search/main.py
+++ b/mex/editor/aux_search/main.py
@@ -122,31 +122,35 @@ def aux_search_result(result: AuxResult, index: int) -> rx.Component:
 
 def search_input() -> rx.Component:
     """Render a search input element that will trigger the results to refresh."""
-    return rx.form(
-        rx.hstack(
-            rx.input(
-                autofocus=True,
-                max_length=100,
-                name="query_string",
-                placeholder="Search here...",
-                style={
-                    "--text-field-selection-color": "",
-                    "--text-field-focus-color": "transparent",
-                    "--text-field-border-width": "1px",
-                    "backgroundClip": "content-box",
-                    "backgroundColor": "transparent",
-                    "boxShadow": (
-                        "inset 0 0 0 var(--text-field-border-width) transparent"
-                    ),
-                    "color": "",
-                },
-                type="text",
+    return rx.center(
+        rx.form(
+            rx.hstack(
+                rx.input(
+                    autofocus=True,
+                    max_length=100,
+                    name="query_string",
+                    placeholder="Search here...",
+                    style={
+                        "--text-field-selection-color": "",
+                        "--text-field-focus-color": "transparent",
+                        "--text-field-border-width": "1px",
+                        "backgroundClip": "content-box",
+                        "backgroundColor": "transparent",
+                        "boxShadow": (
+                            "inset 0 0 0 var(--text-field-border-width) transparent"
+                        ),
+                        "color": "",
+                    },
+                    type="text",
+                ),
+                rx.button(rx.icon("search"), type="submit"),
+                width="100%",
             ),
-            rx.button(rx.icon("search"), type="submit"),
-            width="100%",
-        ),
-        on_submit=[AuxState.handle_submit, AuxState.search],
-        style={"margin": "1em 0 1em"},
+            on_submit=[AuxState.handle_submit, AuxState.search],
+            style={"margin": "1em 0 1em"},
+            justify="center",
+            align="center",
+        )
     )
 
 

--- a/mex/editor/aux_search/main.py
+++ b/mex/editor/aux_search/main.py
@@ -146,7 +146,7 @@ def search_input() -> rx.Component:
                 rx.button(rx.icon("search"), type="submit"),
                 width="100%",
             ),
-            on_submit=[AuxState.handle_submit, AuxState.search],
+            on_submit=AuxState.handle_submit,
             style={"margin": "1em 0 1em"},
             justify="center",
             align="center",

--- a/mex/editor/aux_search/main.py
+++ b/mex/editor/aux_search/main.py
@@ -122,26 +122,31 @@ def aux_search_result(result: AuxResult, index: int) -> rx.Component:
 
 def search_input() -> rx.Component:
     """Render a search input element that will trigger the results to refresh."""
-    return rx.debounce_input(
-        rx.input(
-            rx.input.slot(rx.icon("search"), padding_left="0"),
-            placeholder="Search here...",
-            value=AuxState.query_string,
-            on_change=AuxState.set_query_string,
-            max_length=100,
-            style={
-                "--text-field-selection-color": "",
-                "--text-field-focus-color": "transparent",
-                "--text-field-border-width": "1px",
-                "backgroundClip": "content-box",
-                "backgroundColor": "transparent",
-                "boxShadow": ("inset 0 0 0 var(--text-field-border-width) transparent"),
-                "color": "",
-            },
+    return rx.form(
+        rx.hstack(
+            rx.input(
+                autofocus=True,
+                max_length=100,
+                name="query_string",
+                placeholder="Search here...",
+                style={
+                    "--text-field-selection-color": "",
+                    "--text-field-focus-color": "transparent",
+                    "--text-field-border-width": "1px",
+                    "backgroundClip": "content-box",
+                    "backgroundColor": "transparent",
+                    "boxShadow": (
+                        "inset 0 0 0 var(--text-field-border-width) transparent"
+                    ),
+                    "color": "",
+                },
+                type="text",
+            ),
+            rx.button(rx.icon("search"), type="submit"),
+            width="100%",
         ),
+        on_submit=[AuxState.handle_submit, AuxState.search],
         style={"margin": "1em 0 1em"},
-        debounce_timeout=250,
-        width="100%",
     )
 
 

--- a/mex/editor/aux_search/state.py
+++ b/mex/editor/aux_search/state.py
@@ -64,9 +64,9 @@ class AuxState(State):
         self.current_aux_provider = value
 
     @rx.event
-    def set_query_string(self, value: str) -> Generator[EventSpec | None, None, None]:
-        """Set the query string and refresh the results."""
-        self.query_string = value
+    def handle_submit(self, form_data: dict) -> Generator[EventSpec | None, None, None]:
+        """Handle the form submit."""
+        self.query_string = form_data["query_string"]
         return self.search()
 
     @rx.event

--- a/mex/editor/search/main.py
+++ b/mex/editor/search/main.py
@@ -53,11 +53,20 @@ def search_input() -> rx.Component:
             rx.hstack(
                 rx.input(
                     autofocus=True,
+                    default_value=SearchState.query_string,
+                    max_length=100,
                     name="query_string",
                     placeholder="Search here...",
-                    type="text",
+                    style={
+                        "--text-field-selection-color": "",
+                        "--text-field-focus-color": "transparent",
+                        "--text-field-border-width": "calc(1px * var(--scaling))",
+                        "boxShadow": (
+                            "inset 0 0 0 var(--text-field-border-width) transparent"
+                        ),
+                    },
                     tab_index=1,
-                    default_value=SearchState.query_string,
+                    type="text",
                 ),
                 rx.button(rx.icon("search"), type="submit"),
                 width="100%",
@@ -69,6 +78,7 @@ def search_input() -> rx.Component:
                 SearchState.refresh,
                 SearchState.resolve_identifiers,
             ],
+            style={"margin": "var(--space-4) 0 var(--space-4)"},
         ),
         style={"width": "100%"},
     )

--- a/mex/editor/search/main.py
+++ b/mex/editor/search/main.py
@@ -49,35 +49,26 @@ def search_result(result: SearchResult) -> rx.Component:
 def search_input() -> rx.Component:
     """Render a search input element that will trigger the results to refresh."""
     return rx.card(
-        rx.debounce_input(
-            rx.input(
-                rx.input.slot(
-                    rx.icon("search"),
+        rx.form.root(
+            rx.hstack(
+                rx.input(
                     autofocus=True,
-                    padding_left="0",
+                    name="query_string",
+                    placeholder="Search here...",
+                    type="text",
                     tab_index=1,
+                    default_value=SearchState.query_string,
                 ),
-                placeholder="Search here...",
-                value=SearchState.query_string,
-                on_change=[
-                    SearchState.set_query_string,
-                    SearchState.go_to_first_page,
-                    SearchState.push_search_params,
-                    SearchState.refresh,
-                    SearchState.resolve_identifiers,
-                ],
-                max_length=100,
-                style={
-                    "--text-field-selection-color": "",
-                    "--text-field-focus-color": "transparent",
-                    "--text-field-border-width": "calc(1px * var(--scaling))",
-                    "boxShadow": (
-                        "inset 0 0 0 var(--text-field-border-width) transparent"
-                    ),
-                },
+                rx.button(rx.icon("search"), type="submit"),
+                width="100%",
             ),
-            style={"margin": "var(--space-4) 0 var(--space-4)"},
-            debounce_timeout=250,
+            on_submit=[
+                SearchState.handle_submit,
+                SearchState.go_to_first_page,
+                SearchState.push_search_params,
+                SearchState.refresh,
+                SearchState.resolve_identifiers,
+            ],
         ),
         style={"width": "100%"},
     )

--- a/mex/editor/search/main.py
+++ b/mex/editor/search/main.py
@@ -68,7 +68,11 @@ def search_input() -> rx.Component:
                     tab_index=1,
                     type="text",
                 ),
-                rx.button(rx.icon("search"), type="submit"),
+                rx.button(
+                    rx.icon("search"),
+                    type="submit",
+                    custom_attrs={"data-testid": "search-button"},
+                ),
                 width="100%",
             ),
             on_submit=[

--- a/mex/editor/search/state.py
+++ b/mex/editor/search/state.py
@@ -101,6 +101,11 @@ class SearchState(State):
         self.current_page = int(page_number)
 
     @rx.event
+    def handle_submit(self, form_data: dict) -> None:
+        """Handle the form submit."""
+        self.query_string = form_data["query_string"]
+
+    @rx.event
     def go_to_first_page(self) -> None:
         """Navigate to the first page."""
         self.set_page(1)

--- a/tests/aux_search/test_main.py
+++ b/tests/aux_search/test_main.py
@@ -31,11 +31,13 @@ def test_wikidata_search_and_import_results(aux_page: Page) -> None:
 
     # test search input is showing correctly
     search_input.fill("this doesn't exist gs871s9j91kksWN0shx345jnj")
+    search_input.press("Enter")
     page.screenshot(path="tests_aux_search_test_main-test_search-input-0-found.png")
     expect(page.get_by_text("showing 0 of")).to_be_visible()
 
     # test expand button works
     search_input.fill("rki")
+    search_input.press("Enter")
     expand_all_properties_button = page.get_by_test_id("expand-properties-button").nth(
         1
     )
@@ -70,6 +72,7 @@ def test_ldap_search_and_import_results(aux_page: Page) -> None:
 
     # test search input is showing correctly
     search_input.fill("doesn't exist gs871s9j91k*")
+    search_input.press("Enter")
     expect(page.get_by_text("Showing 0 of")).to_be_visible()
     page.screenshot(
         path="tests_aux_search_test_main-test_ldap_search-input-0-found.png"
@@ -77,6 +80,7 @@ def test_ldap_search_and_import_results(aux_page: Page) -> None:
 
     # test expand button works
     search_input.fill("Ciftci*")
+    search_input.press("Enter")
     expand_all_properties_button = page.get_by_test_id("expand-properties-button").nth(
         1
     )

--- a/tests/search/test_main.py
+++ b/tests/search/test_main.py
@@ -75,12 +75,14 @@ def test_search_input(
     search_input = page.get_by_placeholder("Search here...")
     expect(search_input).to_be_visible()
     search_input.fill("mex")
+    search_input.press("Enter")
     expect(page.get_by_text("Showing 1 of 1 items")).to_be_visible()
     page.screenshot(
         path="tests_search_test_main-test_search_input-on-search-input-1-found.png"
     )
 
     search_input.fill("totally random search dPhGDHu3uiEcU6VNNs0UA74bBdubC3")
+    search_input.press("Enter")
     expect(page.get_by_text("Showing 0 of 0 items")).to_be_visible()
     page.screenshot(
         path="tests_search_test_main-test_search_input-on-search-input-0-found.png"
@@ -218,6 +220,7 @@ def test_push_search_params(
     search_input = page.get_by_placeholder("Search here...")
     expect(search_input).to_be_visible()
     search_input.fill("Can I search here?")
+    search_input.press("Enter")
 
     # expect parameter change to be reflected in url
     page.wait_for_url("**/?q=Can+I+search+here%3F&page=1&entityType=Activity")

--- a/tests/search/test_main.py
+++ b/tests/search/test_main.py
@@ -82,7 +82,7 @@ def test_search_input(
     )
 
     search_input.fill("totally random search dPhGDHu3uiEcU6VNNs0UA74bBdubC3")
-    search_input.press("Enter")
+    page.get_by_test_id("search-button").click()
     expect(page.get_by_text("Showing 0 of 0 items")).to_be_visible()
     page.screenshot(
         path="tests_search_test_main-test_search_input-on-search-input-0-found.png"


### PR DESCRIPTION
### PR Context
<!-- Additional info for the reviewer -->

- Any idea how to place search input symmetrically in box? 
![image](https://github.com/user-attachments/assets/26ec3d1e-8ed4-4e70-8771-54913526870c)
- tests marked with `@pytest.mark.external` fail on this branch but also on main, no idea when they last worked. Search String is submitted to the backend, though.

### Changes
<!-- Changes in existing functionality -->
- search initiation requires hitting enter or clicking the search button
