### PR TITLE
feature/mx-1844 fix temporal options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- only show allowed precisions in temporal field drop-down
+
 ### Security
 
 ## [0.20.0] - 2025-07-08

--- a/mex/editor/fields.py
+++ b/mex/editor/fields.py
@@ -1,13 +1,11 @@
-from typing import TYPE_CHECKING, cast
+from typing import cast
 
 from mex.common.fields import (
     ALL_MODEL_CLASSES_BY_NAME,
     ALL_TYPES_BY_FIELDS_BY_CLASS_NAMES,
     TEMPORAL_FIELDS_BY_CLASS_NAME,
 )
-
-if TYPE_CHECKING:
-    from mex.common.types import AnyTemporalEntity
+from mex.common.types import AnyTemporalEntity, TemporalEntityPrecision
 
 # TODO(ND): move these lookups to mex.common.fields
 
@@ -37,7 +35,7 @@ TEMPORAL_PRECISIONS_BY_FIELD_BY_CLASS_NAMES = {
                     "type[AnyTemporalEntity]", temporal_type
                 ).ALLOWED_PRECISION_LEVELS
             },
-            key=lambda precision: precision.value,
+            key=lambda precision: list(TemporalEntityPrecision).index(precision),
         )
         for field_name in field_names
     }

--- a/mex/editor/fields.py
+++ b/mex/editor/fields.py
@@ -1,5 +1,17 @@
-from mex.common.fields import ALL_MODEL_CLASSES_BY_NAME
+from typing import TYPE_CHECKING, cast
 
+from mex.common.fields import (
+    ALL_MODEL_CLASSES_BY_NAME,
+    ALL_TYPES_BY_FIELDS_BY_CLASS_NAMES,
+    TEMPORAL_FIELDS_BY_CLASS_NAME,
+)
+
+if TYPE_CHECKING:
+    from mex.common.types import AnyTemporalEntity
+
+# TODO(ND): move these lookups to mex.common.fields
+
+# list of fields by class name that are not allowed to be null or an empty list
 REQUIRED_FIELDS_BY_CLASS_NAME = {
     name: sorted(
         {
@@ -9,4 +21,25 @@ REQUIRED_FIELDS_BY_CLASS_NAME = {
         }
     )
     for name, cls in ALL_MODEL_CLASSES_BY_NAME.items()
+}
+
+
+# allowed temporal precisions grouped by field and class names
+TEMPORAL_PRECISIONS_BY_FIELD_BY_CLASS_NAMES = {
+    class_name: {
+        field_name: sorted(
+            {
+                precision
+                for temporal_type in ALL_TYPES_BY_FIELDS_BY_CLASS_NAMES[class_name][
+                    field_name
+                ]
+                for precision in cast(
+                    "type[AnyTemporalEntity]", temporal_type
+                ).ALLOWED_PRECISION_LEVELS
+            },
+            key=lambda precision: precision.value,
+        )
+        for field_name in field_names
+    }
+    for class_name, field_names in TEMPORAL_FIELDS_BY_CLASS_NAME.items()
 }

--- a/mex/editor/rules/main.py
+++ b/mex/editor/rules/main.py
@@ -435,6 +435,7 @@ def field_name(
                 field.is_required,
                 rx.text("*", style={"color": "red"}),
             ),
+            spacing="1",
         ),
         style={"width": "25%"},
         custom_attrs={"data-testid": f"field-{field.name}-name"},

--- a/mex/editor/rules/transform.py
+++ b/mex/editor/rules/transform.py
@@ -38,7 +38,10 @@ from mex.common.types import (
     Text,
     TextLanguage,
 )
-from mex.editor.fields import REQUIRED_FIELDS_BY_CLASS_NAME
+from mex.editor.fields import (
+    REQUIRED_FIELDS_BY_CLASS_NAME,
+    TEMPORAL_PRECISIONS_BY_FIELD_BY_CLASS_NAMES,
+)
 from mex.editor.models import MODEL_CONFIG_BY_STEM_TYPE, EditorValue
 from mex.editor.rules.models import (
     EditorField,
@@ -112,7 +115,12 @@ def _transform_model_to_input_config(  # noqa: PLR0911
             editable_text=editable,
             editable_badge=editable,
             badge_default=TemporalEntityPrecision.YEAR.value,
-            badge_options=[e.value for e in TemporalEntityPrecision],
+            badge_options=[
+                e.value
+                for e in TEMPORAL_PRECISIONS_BY_FIELD_BY_CLASS_NAMES[entity_type][
+                    field_name
+                ]
+            ],
             badge_titles=[TemporalEntityPrecision.__name__],
             allow_additive=editable,
         )

--- a/tests/edit/test_main.py
+++ b/tests/edit/test_main.py
@@ -415,7 +415,7 @@ def test_edit_page_renders_temporal_input(edit_page: Page) -> None:
     )
     precision_options = page.get_by_role("group").get_by_role("option")
     expect(precision_options).to_have_count(3)
-    expect(precision_options).to_have_text(["day", "month", "year"])
+    expect(precision_options).to_have_text(["year", "month", "day"])
 
 
 @pytest.mark.integration

--- a/tests/edit/test_main.py
+++ b/tests/edit/test_main.py
@@ -378,7 +378,7 @@ def test_edit_page_renders_vocabulary_input(edit_page: Page) -> None:
     expect(new_additive_button).to_be_visible()
     new_additive_button.click()
     page.screenshot(
-        path="tests_edit_test_main-test_edit_page_renders_vocabulary_input.png"
+        path="tests_edit_test_main-test_edit_page_renders_vocabulary_input_closed.png"
     )
 
     badge_select = page.get_by_test_id("additive-rule-activityType-0-badge")
@@ -387,9 +387,35 @@ def test_edit_page_renders_vocabulary_input(edit_page: Page) -> None:
     badge_select.focus()
     page.keyboard.press("ArrowDown")
     page.keyboard.press("ArrowDown")
+    page.screenshot(
+        path="tests_edit_test_main-test_edit_page_renders_vocabulary_input_open.png"
+    )
     page.keyboard.press("Enter")
     page.locator("body").focus()
     expect(page.get_by_text("INTERNAL_PROJECT_ENDEAVOR")).to_be_visible()
+
+
+@pytest.mark.integration
+def test_edit_page_renders_temporal_input(edit_page: Page) -> None:
+    page = edit_page
+    new_additive_button = page.get_by_test_id("new-additive-end-00000000000000")
+    new_additive_button.scroll_into_view_if_needed()
+    expect(new_additive_button).to_be_visible()
+    new_additive_button.click()
+    page.screenshot(
+        path="tests_edit_test_main-test_edit_page_renders_temporal_input_closed.png"
+    )
+
+    badge_select = page.get_by_test_id("additive-rule-end-0-badge")
+    expect(badge_select).to_be_visible()
+    expect(page.get_by_text("year")).to_be_visible()
+    badge_select.click()
+    page.screenshot(
+        path="tests_edit_test_main-test_edit_page_renders_temporal_input_open.png"
+    )
+    precision_options = page.get_by_role("group").get_by_role("option")
+    expect(precision_options).to_have_count(3)
+    expect(precision_options).to_have_text(["day", "month", "year"])
 
 
 @pytest.mark.integration


### PR DESCRIPTION

### Fixed

- only show allowed precisions in temporal field drop-down