### PR TITLE
Bump cookiecutter template to 82d72c

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "0eb10763f9de744b839dca9c86e32c5033d3d77a",
+  "commit": "82d72c3719cae04c8057a75f5872faacf24d72a6",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -8,7 +8,7 @@
       "short_summary": "Metadata editor web application.",
       "long_summary": "The `mex-editor` is a browser application that allows creating and editing rules to non-destructively manipulate metadata. This can be used to enrich data with manual input or insert new data from scratch.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "0eb10763f9de744b839dca9c86e32c5033d3d77a"
+      "_commit": "82d72c3719cae04c8057a75f5872faacf24d72a6"
     }
   },
   "directory": null

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          token: ${{ secrets.WORKFLOW_TOKEN }}
 
       - name: Cache requirements
         uses: actions/cache@v4
@@ -72,8 +73,6 @@ jobs:
 
       - name: Release new version
         id: release
-        env:
-          GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
         run: |
           pdm release ${{ inputs.version }}
           echo "tag=$(git describe --abbrev=0 --tags)" >> "$GITHUB_OUTPUT"
@@ -88,6 +87,7 @@ jobs:
         with:
           fetch-depth: 1
           ref: ${{ needs.release.outputs.tag }}
+          persist-credentials: false
 
       - name: Cache requirements
         uses: actions/cache@v4
@@ -136,6 +136,7 @@ jobs:
         with:
           fetch-depth: 1
           ref: ${{ needs.release.outputs.tag }}
+          persist-credentials: false
 
       - name: Cache requirements
         uses: actions/cache@v4


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/82d72c
