### PR TITLE
feature/prep reflex update

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,7 +29,7 @@ jobs:
 
     services:
       neo4j:
-        image: neo4j:2025.05-community
+        image: neo4j:2025.06-community
         env:
           NEO4J_AUTH: neo4j/password
         ports:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- prepare reflex update
+
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes
 
 - prepare reflex update
+- de-duplicate pagination component
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes
 
 - type of aux provider from `str` to `AuxProvider`
-
 - prepare reflex update
 - de-duplicate pagination component
 - de-duplicate ingestion roundtrip tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - prepare reflex update
 - de-duplicate pagination component
+- de-duplicate ingestion roundtrip tests
 
 ### Deprecated
 

--- a/mex/editor/components.py
+++ b/mex/editor/components.py
@@ -1,6 +1,8 @@
 import reflex as rx
 
+from mex.editor.ingest.state import IngestState
 from mex.editor.rules.models import EditorValue
+from mex.editor.search.state import SearchState
 
 
 def render_identifier(value: EditorValue) -> rx.Component:
@@ -96,4 +98,50 @@ def render_value(value: EditorValue) -> rx.Component:
             render_badge(value.badge),
         ),
         spacing="1",
+    )
+
+
+def pagination(state: type[IngestState | SearchState]) -> rx.Component:
+    """Render pagination for navigating search results."""
+    return rx.center(
+        rx.button(
+            rx.text("Previous"),
+            on_click=[
+                state.go_to_previous_page,
+                state.scroll_to_top,
+                state.refresh,
+                state.resolve_identifiers,
+            ],
+            disabled=state.disable_previous_page,
+            variant="surface",
+            custom_attrs={"data-testid": "pagination-previous-button"},
+            style={"minWidth": "10%"},
+        ),
+        rx.select(
+            state.page_selection,
+            value=f"{state.current_page}",
+            on_change=[
+                state.set_page,
+                state.scroll_to_top,
+                state.refresh,
+                state.resolve_identifiers,
+            ],
+            disabled=state.disable_page_selection,
+            custom_attrs={"data-testid": "pagination-page-select"},
+        ),
+        rx.button(
+            rx.text("Next", weight="bold"),
+            on_click=[
+                state.go_to_next_page,
+                state.scroll_to_top,
+                state.refresh,
+                state.resolve_identifiers,
+            ],
+            disabled=state.disable_next_page,
+            variant="surface",
+            custom_attrs={"data-testid": "pagination-next-button"},
+            style={"minWidth": "10%"},
+        ),
+        spacing="4",
+        style={"width": "100%"},
     )

--- a/mex/editor/components.py
+++ b/mex/editor/components.py
@@ -18,8 +18,8 @@ def render_identifier(value: EditorValue) -> rx.Component:
         ),
         loading=rx.cond(
             value.text,
-            c1=True,
-            c2=False,
+            c1=False,
+            c2=True,
         ),
     )
 
@@ -66,8 +66,8 @@ def render_text(value: EditorValue) -> rx.Component:
         ),
         loading=rx.cond(
             value.text,
-            c1=True,
-            c2=False,
+            c1=False,
+            c2=True,
         ),
     )
 

--- a/mex/editor/components.py
+++ b/mex/editor/components.py
@@ -1,5 +1,3 @@
-from typing import cast
-
 import reflex as rx
 
 from mex.editor.rules.models import EditorValue
@@ -9,12 +7,20 @@ def render_identifier(value: EditorValue) -> rx.Component:
     """Render an editor value as a clickable internal link that loads the edit page."""
     return rx.skeleton(
         rx.link(
-            cast("rx.vars.StringVar", value.text) | "Loading ...",
-            href=value.href,
+            rx.cond(
+                value.text,
+                value.text,
+                "Loading ...",
+            ),
+            href=f"{value.href}",
             high_contrast=True,
             role="link",
         ),
-        loading=~cast("rx.vars.StringVar", value.text),
+        loading=rx.cond(
+            value.text,
+            c1=True,
+            c2=False,
+        ),
     )
 
 
@@ -26,7 +32,7 @@ def render_external_link(value: EditorValue) -> rx.Component:
             value.text,
             value.href,
         ),
-        href=value.href,
+        href=f"{value.href}",
         high_contrast=True,
         is_external=True,
         role="link",
@@ -53,8 +59,16 @@ def render_span(text: str | None) -> rx.Component:
 def render_text(value: EditorValue) -> rx.Component:
     """Render an editor value as a text span."""
     return rx.skeleton(
-        render_span(cast("rx.vars.StringVar", value.text) | "Loading ..."),
-        loading=~cast("rx.vars.StringVar", value.text),
+        rx.cond(
+            value.text,
+            render_span(value.text),
+            render_span("Loading ..."),
+        ),
+        loading=rx.cond(
+            value.text,
+            c1=True,
+            c2=False,
+        ),
     )
 
 

--- a/mex/editor/create/main.py
+++ b/mex/editor/create/main.py
@@ -51,7 +51,7 @@ def create_title() -> rx.Component:
             CreateState.available_stem_types,
             value=RuleState.stem_type,
             on_change=[
-                RuleState.set_stem_type,
+                CreateState.set_stem_type,
                 RuleState.refresh,
             ],
             custom_attrs={"data-testid": "entity-type-select"},

--- a/mex/editor/create/state.py
+++ b/mex/editor/create/state.py
@@ -11,5 +11,5 @@ class CreateState(RuleState):
 
     @rx.event
     def reset_stem_type(self) -> None:
-        """Set the stem type to a default."""
+        """Set the stem type to its default."""
         self.stem_type = RULE_SET_REQUEST_CLASSES[0].stemType

--- a/mex/editor/create/state.py
+++ b/mex/editor/create/state.py
@@ -10,6 +10,11 @@ class CreateState(RuleState):
     available_stem_types: list[str] = [r.stemType for r in RULE_SET_REQUEST_CLASSES]
 
     @rx.event
+    def set_stem_type(self, stem_type: str) -> None:
+        """Set the stem type."""
+        self.stem_type = stem_type
+
+    @rx.event
     def reset_stem_type(self) -> None:
         """Set the stem type to its default."""
         self.stem_type = RULE_SET_REQUEST_CLASSES[0].stemType

--- a/mex/editor/edit/state.py
+++ b/mex/editor/edit/state.py
@@ -26,4 +26,4 @@ class EditState(RuleState):
             yield self.show_submit_success_toast()
             params = self.router.page.params.copy()
             params.pop("saved")
-            yield self.push_url_params(**params)
+            yield self.push_url_params(params)

--- a/mex/editor/ingest/main.py
+++ b/mex/editor/ingest/main.py
@@ -149,6 +149,7 @@ def search_input() -> rx.Component:
                         ),
                         "color": "",
                     },
+                    disabled=IngestState.is_loading,
                     type="text",
                 ),
                 rx.button(
@@ -173,6 +174,24 @@ def search_input() -> rx.Component:
     )
 
 
+def results_summary() -> rx.Component:
+    """Render a summary of the results found."""
+    return rx.center(
+        rx.text(
+            f"Showing {IngestState.current_results_length} "
+            f"of {IngestState.total} items",
+            style={
+                "color": "var(--gray-12)",
+                "fontWeight": "var(--font-weight-bold)",
+                "margin": "var(--space-4)",
+                "userSelect": "none",
+            },
+            custom_attrs={"data-testid": "search-results-summary"},
+        ),
+        style={"width": "100%"},
+    )
+
+
 def search_results() -> rx.Component:
     """Render the search results with a heading, result list, and pagination."""
     return rx.cond(
@@ -185,27 +204,18 @@ def search_results() -> rx.Component:
             },
         ),
         rx.vstack(
-            rx.center(
-                rx.text(
-                    f"Showing {IngestState.current_results_length} "
-                    f"of {IngestState.total} items",
-                    style={
-                        "color": "var(--gray-12)",
-                        "fontWeight": "var(--font-weight-bold)",
-                        "margin": "var(--space-4)",
-                        "userSelect": "none",
-                    },
-                    custom_attrs={"data-testid": "search-results-heading"},
-                ),
-                style={"width": "100%"},
-            ),
+            results_summary(),
             rx.foreach(
                 IngestState.results_transformed,
                 ingest_result,
             ),
             pagination(IngestState),
+            spacing="4",
             custom_attrs={"data-testid": "search-results-section"},
-            style={"width": "100%"},
+            style={
+                "minWidth": "0",
+                "width": "100%",
+            },
         ),
     )
 

--- a/mex/editor/ingest/main.py
+++ b/mex/editor/ingest/main.py
@@ -1,5 +1,3 @@
-from typing import cast
-
 import reflex as rx
 
 from mex.editor.components import render_value
@@ -228,7 +226,7 @@ def pagination() -> rx.Component:
         ),
         rx.select(
             IngestState.total_pages,
-            value=cast("rx.vars.NumberVar", IngestState.current_page).to_string(),
+            value=f"{IngestState.current_page}",
             on_change=[
                 IngestState.set_page,
                 IngestState.scroll_to_top,

--- a/mex/editor/ingest/main.py
+++ b/mex/editor/ingest/main.py
@@ -1,6 +1,6 @@
 import reflex as rx
 
-from mex.editor.components import render_value
+from mex.editor.components import pagination, render_value
 from mex.editor.ingest.models import IngestResult
 from mex.editor.ingest.state import IngestState
 from mex.editor.layout import page
@@ -18,7 +18,7 @@ def expand_properties_button(result: IngestResult, index: int) -> rx.Component:
         align="end",
         color_scheme="gray",
         variant="surface",
-        custom_attrs={"data-testid": "expand-properties-button"},
+        custom_attrs={"data-testid": f"expand-properties-button-{index}"},
     )
 
 
@@ -33,6 +33,7 @@ def ingest_button(result: IngestResult, index: int) -> rx.Component:
             variant="surface",
             on_click=IngestState.ingest_result(index),
             width="calc(8em * var(--scaling))",
+            custom_attrs={"data-testid": f"ingest-button-{index}"},
         ),
         rx.button(
             "Ingested",
@@ -41,6 +42,7 @@ def ingest_button(result: IngestResult, index: int) -> rx.Component:
             variant="surface",
             disabled=True,
             width="calc(8em * var(--scaling))",
+            custom_attrs={"data-testid": f"ingest-button-{index}"},
         ),
     )
 
@@ -201,55 +203,10 @@ def search_results() -> rx.Component:
                 IngestState.results_transformed,
                 ingest_result,
             ),
-            pagination(),
+            pagination(IngestState),
             custom_attrs={"data-testid": "search-results-section"},
             style={"width": "100%"},
         ),
-    )
-
-
-def pagination() -> rx.Component:
-    """Render pagination for navigating search results."""
-    return rx.center(
-        rx.button(
-            rx.text("Previous"),
-            on_click=[
-                IngestState.go_to_previous_page,
-                IngestState.scroll_to_top,
-                IngestState.refresh,
-                IngestState.resolve_identifiers,
-            ],
-            disabled=IngestState.disable_previous_page,
-            variant="surface",
-            custom_attrs={"data-testid": "pagination-previous-button"},
-            style={"minWidth": "10%"},
-        ),
-        rx.select(
-            IngestState.total_pages,
-            value=f"{IngestState.current_page}",
-            on_change=[
-                IngestState.set_page,
-                IngestState.scroll_to_top,
-                IngestState.refresh,
-                IngestState.resolve_identifiers,
-            ],
-            custom_attrs={"data-testid": "pagination-page-select"},
-        ),
-        rx.button(
-            rx.text("Next", weight="bold"),
-            on_click=[
-                IngestState.go_to_next_page,
-                IngestState.scroll_to_top,
-                IngestState.refresh,
-                IngestState.resolve_identifiers,
-            ],
-            disabled=IngestState.disable_next_page,
-            variant="surface",
-            custom_attrs={"data-testid": "pagination-next-button"},
-            style={"minWidth": "10%"},
-        ),
-        spacing="4",
-        style={"width": "100%"},
     )
 
 

--- a/mex/editor/ingest/state.py
+++ b/mex/editor/ingest/state.py
@@ -31,9 +31,14 @@ class IngestState(State):
     is_loading: bool = True
 
     @rx.var(cache=False)
-    def total_pages(self) -> list[str]:
+    def page_selection(self) -> list[str]:
         """Return a list of total pages based on the number of results."""
         return [f"{i + 1}" for i in range(math.ceil(self.total / self.limit))]
+
+    @rx.var(cache=False)
+    def disable_page_selection(self) -> bool:
+        """Whether the page selection in the pagination should be disabled."""
+        return math.ceil(self.total / self.limit) == 1
 
     @rx.var(cache=False)
     def disable_previous_page(self) -> bool:

--- a/mex/editor/ingest/state.py
+++ b/mex/editor/ingest/state.py
@@ -76,17 +76,17 @@ class IngestState(State):
     @rx.event
     def go_to_first_page(self) -> None:
         """Navigate to the first page."""
-        self.set_page(1)
+        self.current_page = 1
 
     @rx.event
     def go_to_previous_page(self) -> None:
         """Navigate to the previous page."""
-        self.set_page(self.current_page - 1)
+        self.current_page = self.current_page - 1
 
     @rx.event
     def go_to_next_page(self) -> None:
         """Navigate to the next page."""
-        self.set_page(self.current_page + 1)
+        self.current_page = self.current_page + 1
 
     @rx.event
     def ingest_result(self, index: int) -> Generator[EventSpec | None, None, None]:

--- a/mex/editor/layout.py
+++ b/mex/editor/layout.py
@@ -56,7 +56,7 @@ def app_logo() -> rx.Component:
         rx.hover_card.trigger(
             rx.hstack(
                 rx.icon(
-                    "circuit-board",
+                    tag="circuit-board",
                     size=28,
                 ),
                 rx.heading(

--- a/mex/editor/login/main.py
+++ b/mex/editor/login/main.py
@@ -4,7 +4,7 @@ from mex.editor.layout import app_logo
 from mex.editor.login.state import LoginLdapState, LoginMExState
 
 
-def login_user(state: type[rx.State]) -> rx.Component:
+def login_user(state: type[LoginLdapState | LoginMExState]) -> rx.Component:
     """Return a form field for the user name."""
     return rx.vstack(
         rx.text("Username"),
@@ -21,7 +21,7 @@ def login_user(state: type[rx.State]) -> rx.Component:
     )
 
 
-def login_password(state: type[rx.State]) -> rx.Component:
+def login_password(state: type[LoginLdapState | LoginMExState]) -> rx.Component:
     """Return a form field for the password."""
     return rx.vstack(
         rx.text("Password"),
@@ -57,7 +57,7 @@ def login_button() -> rx.Component:
     )
 
 
-def login_form(state: type[rx.State]) -> rx.Component:
+def login_form(state: type[LoginLdapState | LoginMExState]) -> rx.Component:
     """Return a login form."""
     return rx.center(
         rx.card(

--- a/mex/editor/login/state.py
+++ b/mex/editor/login/state.py
@@ -18,6 +18,16 @@ class LoginLdapState(State):
     password: str
 
     @rx.event
+    def set_username(self, username: str) -> None:
+        """Set the username."""
+        self.username = username
+
+    @rx.event
+    def set_password(self, password: str) -> None:
+        """Set the password."""
+        self.password = password
+
+    @rx.event
     def login(self) -> EventSpec:
         """Login a user."""
         write_access = has_write_access_ldap(self.username, self.password)
@@ -42,6 +52,16 @@ class LoginMExState(State):
 
     username: str
     password: str
+
+    @rx.event
+    def set_username(self, username: str) -> None:
+        """Set the username."""
+        self.username = username
+
+    @rx.event
+    def set_password(self, password: str) -> None:
+        """Set the password."""
+        self.password = password
 
     @rx.event
     def login(self) -> EventSpec:

--- a/mex/editor/main.py
+++ b/mex/editor/main.py
@@ -22,11 +22,10 @@ def editor_api() -> None:  # pragma: no cover
     # Set the log level.
     set_log_level(constants.LogLevel.INFO)
 
-    # Set env mode in the environment.
+    # Set environment variables.
     environment.REFLEX_ENV_MODE.set(constants.Env.PROD)
-
-    # Skip the compile step.
     environment.REFLEX_SKIP_COMPILE.set(True)
+    environment.REFLEX_USE_GRANIAN.set(False)
 
     # Delete the states folder if it exists.
     reset_disk_state_manager()
@@ -57,7 +56,7 @@ def editor_frontend() -> None:  # pragma: no cover
     environment.REFLEX_CHECK_LATEST_VERSION.set(False)
 
     # Initialize the app in the current directory.
-    _init(name="mex", loglevel=constants.LogLevel.INFO)
+    _init(name="mex")
 
     # Get the app module.
     get_compiled_app()
@@ -78,5 +77,9 @@ def editor_frontend() -> None:  # pragma: no cover
 
 def main() -> None:  # pragma: no cover
     """Start the editor api together with frontend."""
+    # Set environment variables.
     environment.REFLEX_USE_NPM.set(True)
+    environment.REFLEX_USE_GRANIAN.set(False)
+
+    # Run the editor.
     typer.run(run)

--- a/mex/editor/merge/state.py
+++ b/mex/editor/merge/state.py
@@ -118,7 +118,6 @@ class MergeState(State):
             self.selected_items["extracted"] = None
             yield from self._refresh_extracted()
 
-    @rx.event
     def _refresh_merged(self) -> Generator[EventSpec | None, None, None]:
         """Refresh the search results for merged items."""
         connector = BackendApiConnector.get()
@@ -150,7 +149,6 @@ class MergeState(State):
             self.results_count["merged"] = len(self.results_merged)
             self.total_count["merged"] = response.total
 
-    @rx.event
     def _refresh_extracted(self) -> Generator[EventSpec | None, None, None]:
         """Refresh the search results for extracted items."""
         connector = BackendApiConnector.get()

--- a/mex/editor/models.yaml
+++ b/mex/editor/models.yaml
@@ -31,6 +31,8 @@ Consent:
   icon: badge-check
 ContactPoint:
   title: email
+  preview:
+    - email
   icon: inbox
 Distribution:
   title: title

--- a/mex/editor/rules/main.py
+++ b/mex/editor/rules/main.py
@@ -181,8 +181,11 @@ def badge_input(
         rx.box(
             rx.select(
                 input_config.badge_options,
-                value=cast("rx.Var", badge)
-                | cast("rx.Var", input_config.badge_default),
+                value=rx.cond(
+                    badge,
+                    badge,
+                    input_config.badge_default,
+                ),
                 size="1",
                 variant="soft",
                 radius="large",
@@ -259,8 +262,11 @@ def additive_rule_input(
                 rx.box(
                     rx.select(
                         input_config.badge_options,
-                        value=cast("rx.Var", value.badge)
-                        | cast("rx.Var", input_config.badge_default),
+                        value=rx.cond(
+                            value.badge,
+                            value.badge,
+                            input_config.badge_default,
+                        ),
                         size="1",
                         variant="soft",
                         radius="large",

--- a/mex/editor/rules/models.py
+++ b/mex/editor/rules/models.py
@@ -31,13 +31,13 @@ class EditorPrimarySource(rx.Base):
     name: EditorValue
     identifier: MergedPrimarySourceIdentifier
     input_config: InputConfig
-    editor_values: list[EditorValue] = []
-    enabled: bool = True
+    editor_values: list[EditorValue]
+    enabled: bool
 
 
 class EditorField(rx.Base):
     """Model for describing the editor state for a single field."""
 
     name: str
-    primary_sources: list[EditorPrimarySource] = []
+    primary_sources: list[EditorPrimarySource]
     is_required: bool

--- a/mex/editor/search/main.py
+++ b/mex/editor/search/main.py
@@ -1,6 +1,6 @@
 import reflex as rx
 
-from mex.editor.components import render_value
+from mex.editor.components import pagination, render_value
 from mex.editor.layout import page
 from mex.editor.search.models import SearchPrimarySource, SearchResult
 from mex.editor.search.state import SearchState
@@ -174,54 +174,6 @@ def sidebar() -> rx.Component:
     )
 
 
-def pagination() -> rx.Component:
-    """Render pagination for navigating search results."""
-    return rx.center(
-        rx.button(
-            rx.text("Previous"),
-            on_click=[
-                SearchState.go_to_previous_page,
-                SearchState.push_search_params,
-                SearchState.scroll_to_top,
-                SearchState.refresh,
-                SearchState.resolve_identifiers,
-            ],
-            disabled=SearchState.disable_previous_page,
-            variant="surface",
-            custom_attrs={"data-testid": "pagination-previous-button"},
-            style={"minWidth": "10%"},
-        ),
-        rx.select(
-            SearchState.total_pages,
-            value=f"{SearchState.current_page}",
-            on_change=[
-                SearchState.set_page,
-                SearchState.push_search_params,
-                SearchState.scroll_to_top,
-                SearchState.refresh,
-                SearchState.resolve_identifiers,
-            ],
-            custom_attrs={"data-testid": "pagination-page-select"},
-        ),
-        rx.button(
-            rx.text("Next"),
-            on_click=[
-                SearchState.go_to_next_page,
-                SearchState.push_search_params,
-                SearchState.scroll_to_top,
-                SearchState.refresh,
-                SearchState.resolve_identifiers,
-            ],
-            disabled=SearchState.disable_next_page,
-            variant="surface",
-            custom_attrs={"data-testid": "pagination-next-button"},
-            style={"minWidth": "10%"},
-        ),
-        spacing="4",
-        style={"width": "100%"},
-    )
-
-
 def results_summary() -> rx.Component:
     """Render a summary of the results found."""
     return rx.center(
@@ -257,7 +209,7 @@ def search_results() -> rx.Component:
                 SearchState.results,
                 search_result,
             ),
-            pagination(),
+            pagination(SearchState),
             spacing="4",
             custom_attrs={"data-testid": "search-results-section"},
             style={

--- a/mex/editor/search/main.py
+++ b/mex/editor/search/main.py
@@ -1,5 +1,3 @@
-from typing import cast
-
 import reflex as rx
 
 from mex.editor.components import render_value
@@ -195,7 +193,7 @@ def pagination() -> rx.Component:
         ),
         rx.select(
             SearchState.total_pages,
-            value=cast("rx.vars.NumberVar", SearchState.current_page).to_string(),
+            value=f"{SearchState.current_page}",
             on_change=[
                 SearchState.set_page,
                 SearchState.push_search_params,

--- a/mex/editor/search/state.py
+++ b/mex/editor/search/state.py
@@ -78,12 +78,14 @@ class SearchState(State):
     def push_search_params(self) -> EventSpec | None:
         """Push a new browser history item with updated search parameters."""
         return self.push_url_params(
-            q=self.query_string,
-            page=self.current_page,
-            entityType=[k for k, v in self.entity_types.items() if v],
-            hadPrimarySource=[
-                k for k, v in self.had_primary_sources.items() if v.checked
-            ],
+            {
+                "q": self.query_string,
+                "page": self.current_page,
+                "entityType": [k for k, v in self.entity_types.items() if v],
+                "hadPrimarySource": [
+                    k for k, v in self.had_primary_sources.items() if v.checked
+                ],
+            },
         )
 
     @rx.event
@@ -117,17 +119,17 @@ class SearchState(State):
     @rx.event
     def go_to_first_page(self) -> None:
         """Navigate to the first page."""
-        self.set_page(1)
+        self.current_page = 1
 
     @rx.event
     def go_to_previous_page(self) -> None:
         """Navigate to the previous page."""
-        self.set_page(self.current_page - 1)
+        self.current_page = self.current_page - 1
 
     @rx.event
     def go_to_next_page(self) -> None:
         """Navigate to the next page."""
-        self.set_page(self.current_page + 1)
+        self.current_page = self.current_page + 1
 
     @rx.event
     def scroll_to_top(self) -> Generator[EventSpec | None, None, None]:
@@ -212,7 +214,7 @@ class SearchState(State):
             search_primary_sources = [
                 SearchPrimarySource(
                     identifier=source.identifier,
-                    title=source.title[0].text,
+                    title=source.title[0].text or "",
                     checked=False,
                 )
                 for source in available_primary_sources

--- a/mex/editor/search/state.py
+++ b/mex/editor/search/state.py
@@ -50,9 +50,14 @@ class SearchState(State):
         return len(self.results)
 
     @rx.var(cache=False)
-    def total_pages(self) -> list[str]:
+    def page_selection(self) -> list[str]:
         """Return a list of total pages based on the number of results."""
         return [f"{i + 1}" for i in range(math.ceil(self.total / self.limit))]
+
+    @rx.var(cache=False)
+    def disable_page_selection(self) -> bool:
+        """Whether the page selection in the pagination should be disabled."""
+        return math.ceil(self.total / self.limit) == 1
 
     @rx.event
     def load_search_params(self) -> None:

--- a/mex/editor/state.py
+++ b/mex/editor/state.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from importlib.metadata import version
 from urllib.parse import urlencode
 
@@ -66,7 +67,10 @@ class State(rx.State):
         return None
 
     @staticmethod
-    def _update_raw_path(nav_item: NavItem, **params: int | str | list[str]) -> None:
+    def _update_raw_path(
+        nav_item: NavItem,
+        params: Mapping[str, int | str | list[str]],
+    ) -> None:
         """Update the raw path of a nav item with the given parameters."""
         raw_path = nav_item.path
         param_tuples = list(params.items())
@@ -83,11 +87,14 @@ class State(rx.State):
         nav_item.raw_path = raw_path
 
     @rx.event
-    def push_url_params(self, **params: int | str | list[str]) -> EventSpec | None:
+    def push_url_params(
+        self,
+        params: Mapping[str, int | str | list[str]],
+    ) -> EventSpec | None:
         """Event handler to push updated url parameter to the browser history."""
         for nav_item in self.nav_items:
             if self.router.page.path == nav_item.path:
-                self._update_raw_path(nav_item, **params)
+                self._update_raw_path(nav_item, params)
                 return rx.call_script(
                     f"window.history.pushState(null, '', '{nav_item.raw_path}');"
                 )
@@ -98,7 +105,7 @@ class State(rx.State):
         """Event hook for updating the navigation on page loads."""
         for nav_item in self.nav_items:
             if self.router.page.path == nav_item.path:
-                self._update_raw_path(nav_item, **self.router.page.params)
+                self._update_raw_path(nav_item, self.router.page.params)
                 nav_item.underline = "always"
             else:
                 nav_item.underline = "none"

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:ef32f5e908578d78608a4061e7556610bd5b5663dca27b057c402a32798abbab"
+content_hash = "sha256:255f0b2041ce3331721032fe331e33cd9f788a1a4d8de3d8d28f5be2ce4033f7"
 
 [[metadata.targets]]
 requires_python = "==3.11.*"
@@ -254,7 +254,7 @@ version = "0.4.6"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 summary = "Cross-platform colored terminal text."
 groups = ["default", "dev"]
-marker = "sys_platform == \"win32\" or platform_system == \"Windows\" or os_name == \"nt\""
+marker = "platform_system == \"Windows\" or sys_platform == \"win32\" or os_name == \"nt\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
@@ -865,25 +865,25 @@ files = [
 
 [[package]]
 name = "mex-artificial"
-version = "0.5.2"
+version = "0.5.3"
 requires_python = "<3.13,>=3.11"
 summary = "Create artificial data for the MEx project."
 groups = ["dev"]
 dependencies = [
     "annotated-types<=0.7",
     "faker<38,>=37",
-    "mex-common<0.64,>=0.63",
+    "mex-common>=0.64",
     "pydantic>=2",
     "typer>=0.13",
 ]
 files = [
-    {file = "mex_artificial-0.5.2-py3-none-any.whl", hash = "sha256:97b7f8896c48919b890304ecf12d3ac1211e7bf2b0f509d22fa76f27587d4a6f"},
-    {file = "mex_artificial-0.5.2.tar.gz", hash = "sha256:65e62d0c815043e2b49dcd29cc0533fb7a3017d52e899dd12629a6205f99fabe"},
+    {file = "mex_artificial-0.5.3-py3-none-any.whl", hash = "sha256:2becbfdea08ed0d57580e9e074370230cf60a5c83bca9fccee72456acf9596a7"},
+    {file = "mex_artificial-0.5.3.tar.gz", hash = "sha256:8a6c1dd421ef6ccae91f34dea5a223d625ced83b8b7263803fb0ed9b9920293c"},
 ]
 
 [[package]]
 name = "mex-common"
-version = "0.63.0"
+version = "0.64.0"
 requires_python = "<3.12,>=3.11"
 summary = "Common library for MEx python projects."
 groups = ["default", "dev"]
@@ -892,7 +892,7 @@ dependencies = [
     "click<9,>=8",
     "langdetect<2,>=1",
     "ldap3<3,>=2",
-    "mex-model==4.1.0",
+    "mex-model==4.1.1",
     "numpy<3,>=2",
     "pandas<3,>=2",
     "pyarrow<21,>=20",
@@ -902,19 +902,19 @@ dependencies = [
     "requests<3,>=2",
 ]
 files = [
-    {file = "mex_common-0.63.0-py3-none-any.whl", hash = "sha256:1fefb1b62eace93587cfc0d3b20249afaa4cc692362a29a60600f6cd7557c2f6"},
-    {file = "mex_common-0.63.0.tar.gz", hash = "sha256:b3aa98651f754adf9ab146697d00b88381d7114a6d998e661365e41d7b18d4da"},
+    {file = "mex_common-0.64.0-py3-none-any.whl", hash = "sha256:623f1f06132c48809a9b38fa60e8363dd18289e7547766f834965c97080e346e"},
+    {file = "mex_common-0.64.0.tar.gz", hash = "sha256:4d1a70864b3f766ceee2628801ddf93b08a3be30496b4ace3237579b8d080b77"},
 ]
 
 [[package]]
 name = "mex-model"
-version = "4.1.0"
+version = "4.1.1"
 requires_python = ">=3.9"
 summary = "JSON schema files defining the MEx metadata model."
 groups = ["default", "dev"]
 files = [
-    {file = "mex_model-4.1.0-py3-none-any.whl", hash = "sha256:f9f4fa08416207e8ccc31c57a846abd50f93bb8fa15de63a5b77524a8b828cf2"},
-    {file = "mex_model-4.1.0.tar.gz", hash = "sha256:76112cc0a2e298da8fadf6b257fc72899f6ae0fb0ca0760448a834278f14953a"},
+    {file = "mex_model-4.1.1-py3-none-any.whl", hash = "sha256:cfe3359ae84c1b747a75f6ca44d1df886c0d66621a8a2c5e8f6d71729ebce19d"},
+    {file = "mex_model-4.1.1.tar.gz", hash = "sha256:702d016d8a96e5aeaa84aaea1ea6203d2648b7cbd1075d88eecb2a91c6fe08e1"},
 ]
 
 [[package]]

--- a/pdm.lock
+++ b/pdm.lock
@@ -254,7 +254,7 @@ version = "0.4.6"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 summary = "Cross-platform colored terminal text."
 groups = ["default", "dev"]
-marker = "platform_system == \"Windows\" or sys_platform == \"win32\" or os_name == \"nt\""
+marker = "sys_platform == \"win32\" or platform_system == \"Windows\" or os_name == \"nt\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
@@ -402,7 +402,7 @@ files = [
 
 [[package]]
 name = "faker"
-version = "37.4.2"
+version = "37.5.3"
 requires_python = ">=3.9"
 summary = "Faker is a Python package that generates fake data for you."
 groups = ["dev"]
@@ -410,8 +410,8 @@ dependencies = [
     "tzdata",
 ]
 files = [
-    {file = "faker-37.4.2-py3-none-any.whl", hash = "sha256:b70ed1af57bfe988cbcd0afd95f4768c51eaf4e1ce8a30962e127ac5c139c93f"},
-    {file = "faker-37.4.2.tar.gz", hash = "sha256:8e281bbaea30e5658895b8bea21cc50d27aaf3a43db3f2694409ca5701c56b0a"},
+    {file = "faker-37.5.3-py3-none-any.whl", hash = "sha256:386fe9d5e6132a915984bf887fcebcc72d6366a25dd5952905b31b141a17016d"},
+    {file = "faker-37.5.3.tar.gz", hash = "sha256:8315d8ff4d6f4f588bd42ffe63abd599886c785073e26a44707e10eeba5713dc"},
 ]
 
 [[package]]
@@ -931,7 +931,7 @@ files = [
 
 [[package]]
 name = "mypy"
-version = "1.17.0"
+version = "1.17.1"
 requires_python = ">=3.9"
 summary = "Optional static typing for Python"
 groups = ["dev"]
@@ -942,14 +942,14 @@ dependencies = [
     "typing-extensions>=4.6.0",
 ]
 files = [
-    {file = "mypy-1.17.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:9d4fe5c72fd262d9c2c91c1117d16aac555e05f5beb2bae6a755274c6eec42be"},
-    {file = "mypy-1.17.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d96b196e5c16f41b4f7736840e8455958e832871990c7ba26bf58175e357ed61"},
-    {file = "mypy-1.17.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:73a0ff2dd10337ceb521c080d4147755ee302dcde6e1a913babd59473904615f"},
-    {file = "mypy-1.17.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24cfcc1179c4447854e9e406d3af0f77736d631ec87d31c6281ecd5025df625d"},
-    {file = "mypy-1.17.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3c56f180ff6430e6373db7a1d569317675b0a451caf5fef6ce4ab365f5f2f6c3"},
-    {file = "mypy-1.17.0-cp311-cp311-win_amd64.whl", hash = "sha256:eafaf8b9252734400f9b77df98b4eee3d2eecab16104680d51341c75702cad70"},
-    {file = "mypy-1.17.0-py3-none-any.whl", hash = "sha256:15d9d0018237ab058e5de3d8fce61b6fa72cc59cc78fd91f1b474bce12abf496"},
-    {file = "mypy-1.17.0.tar.gz", hash = "sha256:e5d7ccc08ba089c06e2f5629c660388ef1fee708444f1dee0b9203fa031dee03"},
+    {file = "mypy-1.17.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ad37544be07c5d7fba814eb370e006df58fed8ad1ef33ed1649cb1889ba6ff58"},
+    {file = "mypy-1.17.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:064e2ff508e5464b4bd807a7c1625bc5047c5022b85c70f030680e18f37273a5"},
+    {file = "mypy-1.17.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:70401bbabd2fa1aa7c43bb358f54037baf0586f41e83b0ae67dd0534fc64edfd"},
+    {file = "mypy-1.17.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e92bdc656b7757c438660f775f872a669b8ff374edc4d18277d86b63edba6b8b"},
+    {file = "mypy-1.17.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c1fdf4abb29ed1cb091cf432979e162c208a5ac676ce35010373ff29247bcad5"},
+    {file = "mypy-1.17.1-cp311-cp311-win_amd64.whl", hash = "sha256:ff2933428516ab63f961644bc49bc4cbe42bbffb2cd3b71cc7277c07d16b1a8b"},
+    {file = "mypy-1.17.1-py3-none-any.whl", hash = "sha256:a9f52c0351c21fe24c21d8c0eb1f62967b262d6729393397b6f443c3b773c3b9"},
+    {file = "mypy-1.17.1.tar.gz", hash = "sha256:25e01ec741ab5bb3eec8ba9cdb0f769230368a22c959c4937360efb89b7e9f01"},
 ]
 
 [[package]]
@@ -1723,29 +1723,29 @@ files = [
 
 [[package]]
 name = "ruff"
-version = "0.12.5"
+version = "0.12.7"
 requires_python = ">=3.7"
 summary = "An extremely fast Python linter and code formatter, written in Rust."
 groups = ["dev"]
 files = [
-    {file = "ruff-0.12.5-py3-none-linux_armv6l.whl", hash = "sha256:1de2c887e9dec6cb31fcb9948299de5b2db38144e66403b9660c9548a67abd92"},
-    {file = "ruff-0.12.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:d1ab65e7d8152f519e7dea4de892317c9da7a108da1c56b6a3c1d5e7cf4c5e9a"},
-    {file = "ruff-0.12.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:962775ed5b27c7aa3fdc0d8f4d4433deae7659ef99ea20f783d666e77338b8cf"},
-    {file = "ruff-0.12.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:73b4cae449597e7195a49eb1cdca89fd9fbb16140c7579899e87f4c85bf82f73"},
-    {file = "ruff-0.12.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8b13489c3dc50de5e2d40110c0cce371e00186b880842e245186ca862bf9a1ac"},
-    {file = "ruff-0.12.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f1504fea81461cf4841778b3ef0a078757602a3b3ea4b008feb1308cb3f23e08"},
-    {file = "ruff-0.12.5-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:c7da4129016ae26c32dfcbd5b671fe652b5ab7fc40095d80dcff78175e7eddd4"},
-    {file = "ruff-0.12.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ca972c80f7ebcfd8af75a0f18b17c42d9f1ef203d163669150453f50ca98ab7b"},
-    {file = "ruff-0.12.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8dbbf9f25dfb501f4237ae7501d6364b76a01341c6f1b2cd6764fe449124bb2a"},
-    {file = "ruff-0.12.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2c47dea6ae39421851685141ba9734767f960113d51e83fd7bb9958d5be8763a"},
-    {file = "ruff-0.12.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:c5076aa0e61e30f848846f0265c873c249d4b558105b221be1828f9f79903dc5"},
-    {file = "ruff-0.12.5-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a5a4c7830dadd3d8c39b1cc85386e2c1e62344f20766be6f173c22fb5f72f293"},
-    {file = "ruff-0.12.5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:46699f73c2b5b137b9dc0fc1a190b43e35b008b398c6066ea1350cce6326adcb"},
-    {file = "ruff-0.12.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5a655a0a0d396f0f072faafc18ebd59adde8ca85fb848dc1b0d9f024b9c4d3bb"},
-    {file = "ruff-0.12.5-py3-none-win32.whl", hash = "sha256:dfeb2627c459b0b78ca2bbdc38dd11cc9a0a88bf91db982058b26ce41714ffa9"},
-    {file = "ruff-0.12.5-py3-none-win_amd64.whl", hash = "sha256:ae0d90cf5f49466c954991b9d8b953bd093c32c27608e409ae3564c63c5306a5"},
-    {file = "ruff-0.12.5-py3-none-win_arm64.whl", hash = "sha256:48cdbfc633de2c5c37d9f090ba3b352d1576b0015bfc3bc98eaf230275b7e805"},
-    {file = "ruff-0.12.5.tar.gz", hash = "sha256:b209db6102b66f13625940b7f8c7d0f18e20039bb7f6101fbdac935c9612057e"},
+    {file = "ruff-0.12.7-py3-none-linux_armv6l.whl", hash = "sha256:76e4f31529899b8c434c3c1dede98c4483b89590e15fb49f2d46183801565303"},
+    {file = "ruff-0.12.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:789b7a03e72507c54fb3ba6209e4bb36517b90f1a3569ea17084e3fd295500fb"},
+    {file = "ruff-0.12.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2e1c2a3b8626339bb6369116e7030a4cf194ea48f49b64bb505732a7fce4f4e3"},
+    {file = "ruff-0.12.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32dec41817623d388e645612ec70d5757a6d9c035f3744a52c7b195a57e03860"},
+    {file = "ruff-0.12.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47ef751f722053a5df5fa48d412dbb54d41ab9b17875c6840a58ec63ff0c247c"},
+    {file = "ruff-0.12.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a828a5fc25a3efd3e1ff7b241fd392686c9386f20e5ac90aa9234a5faa12c423"},
+    {file = "ruff-0.12.7-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:5726f59b171111fa6a69d82aef48f00b56598b03a22f0f4170664ff4d8298efb"},
+    {file = "ruff-0.12.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:74e6f5c04c4dd4aba223f4fe6e7104f79e0eebf7d307e4f9b18c18362124bccd"},
+    {file = "ruff-0.12.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5d0bfe4e77fba61bf2ccadf8cf005d6133e3ce08793bbe870dd1c734f2699a3e"},
+    {file = "ruff-0.12.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06bfb01e1623bf7f59ea749a841da56f8f653d641bfd046edee32ede7ff6c606"},
+    {file = "ruff-0.12.7-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e41df94a957d50083fd09b916d6e89e497246698c3f3d5c681c8b3e7b9bb4ac8"},
+    {file = "ruff-0.12.7-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:4000623300563c709458d0ce170c3d0d788c23a058912f28bbadc6f905d67afa"},
+    {file = "ruff-0.12.7-py3-none-musllinux_1_2_i686.whl", hash = "sha256:69ffe0e5f9b2cf2b8e289a3f8945b402a1b19eff24ec389f45f23c42a3dd6fb5"},
+    {file = "ruff-0.12.7-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a07a5c8ffa2611a52732bdc67bf88e243abd84fe2d7f6daef3826b59abbfeda4"},
+    {file = "ruff-0.12.7-py3-none-win32.whl", hash = "sha256:c928f1b2ec59fb77dfdf70e0419408898b63998789cc98197e15f560b9e77f77"},
+    {file = "ruff-0.12.7-py3-none-win_amd64.whl", hash = "sha256:9c18f3d707ee9edf89da76131956aba1270c6348bfee8f6c647de841eac7194f"},
+    {file = "ruff-0.12.7-py3-none-win_arm64.whl", hash = "sha256:dfce05101dbd11833a0776716d5d1578641b7fddb537fe7fa956ab85d1769b69"},
+    {file = "ruff-0.12.7.tar.gz", hash = "sha256:1fc3193f238bc2d7968772c82831a4ff69252f673be371fb49663f0068b7ec71"},
 ]
 
 [[package]]
@@ -1931,7 +1931,7 @@ files = [
 
 [[package]]
 name = "sqlalchemy"
-version = "2.0.41"
+version = "2.0.42"
 requires_python = ">=3.7"
 summary = "Database Abstraction Library"
 groups = ["default"]
@@ -1941,16 +1941,16 @@ dependencies = [
     "typing-extensions>=4.6.0",
 ]
 files = [
-    {file = "sqlalchemy-2.0.41-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6375cd674fe82d7aa9816d1cb96ec592bac1726c11e0cafbf40eeee9a4516b5f"},
-    {file = "sqlalchemy-2.0.41-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9f8c9fdd15a55d9465e590a402f42082705d66b05afc3ffd2d2eb3c6ba919560"},
-    {file = "sqlalchemy-2.0.41-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32f9dc8c44acdee06c8fc6440db9eae8b4af8b01e4b1aee7bdd7241c22edff4f"},
-    {file = "sqlalchemy-2.0.41-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90c11ceb9a1f482c752a71f203a81858625d8df5746d787a4786bca4ffdf71c6"},
-    {file = "sqlalchemy-2.0.41-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:911cc493ebd60de5f285bcae0491a60b4f2a9f0f5c270edd1c4dbaef7a38fc04"},
-    {file = "sqlalchemy-2.0.41-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:03968a349db483936c249f4d9cd14ff2c296adfa1290b660ba6516f973139582"},
-    {file = "sqlalchemy-2.0.41-cp311-cp311-win32.whl", hash = "sha256:293cd444d82b18da48c9f71cd7005844dbbd06ca19be1ccf6779154439eec0b8"},
-    {file = "sqlalchemy-2.0.41-cp311-cp311-win_amd64.whl", hash = "sha256:3d3549fc3e40667ec7199033a4e40a2f669898a00a7b18a931d3efb4c7900504"},
-    {file = "sqlalchemy-2.0.41-py3-none-any.whl", hash = "sha256:57df5dc6fdb5ed1a88a1ed2195fd31927e705cad62dedd86b46972752a80f576"},
-    {file = "sqlalchemy-2.0.41.tar.gz", hash = "sha256:edba70118c4be3c2b1f90754d308d0b79c6fe2c0fdc52d8ddf603916f83f4db9"},
+    {file = "sqlalchemy-2.0.42-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c34100c0b7ea31fbc113c124bcf93a53094f8951c7bf39c45f39d327bad6d1e7"},
+    {file = "sqlalchemy-2.0.42-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ad59dbe4d1252448c19d171dfba14c74e7950b46dc49d015722a4a06bfdab2b0"},
+    {file = "sqlalchemy-2.0.42-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f9187498c2149919753a7fd51766ea9c8eecdec7da47c1b955fa8090bc642eaa"},
+    {file = "sqlalchemy-2.0.42-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1f092cf83ebcafba23a247f5e03f99f5436e3ef026d01c8213b5eca48ad6efa9"},
+    {file = "sqlalchemy-2.0.42-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:fc6afee7e66fdba4f5a68610b487c1f754fccdc53894a9567785932dbb6a265e"},
+    {file = "sqlalchemy-2.0.42-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:260ca1d2e5910f1f1ad3fe0113f8fab28657cee2542cb48c2f342ed90046e8ec"},
+    {file = "sqlalchemy-2.0.42-cp311-cp311-win32.whl", hash = "sha256:2eb539fd83185a85e5fcd6b19214e1c734ab0351d81505b0f987705ba0a1e231"},
+    {file = "sqlalchemy-2.0.42-cp311-cp311-win_amd64.whl", hash = "sha256:9193fa484bf00dcc1804aecbb4f528f1123c04bad6a08d7710c909750fa76aeb"},
+    {file = "sqlalchemy-2.0.42-py3-none-any.whl", hash = "sha256:defcdff7e661f0043daa381832af65d616e060ddb54d3fe4476f51df7eaa1835"},
+    {file = "sqlalchemy-2.0.42.tar.gz", hash = "sha256:160bedd8a5c28765bd5be4dec2d881e109e33b34922e50a3b881a7681773ac5f"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.11,<3.12"
 dependencies = [
     "async-lru>=2",
     "fastapi>=0.115",
-    "mex-common>=0.63,<0.64",
+    "mex-common>=0.64,<0.65",
     "pydantic>=2",
     "pyyaml>=6",
     "reflex>=0.6,<0.7",

--- a/tests/ingest/test_main.py
+++ b/tests/ingest/test_main.py
@@ -22,141 +22,105 @@ def test_aux_tab_section(ingest_page: Page) -> None:
     expect(nav_bar).to_be_visible()
 
 
+@pytest.mark.parametrize(
+    ("aux_provider", "stem_type", "invalid_search", "valid_search"),
+    [
+        (
+            "ldap",
+            "Person",
+            "doesn't exist gs871s9j91k*",
+            "L*",
+        ),
+        (
+            "wikidata",
+            "Organization",
+            "Q000000",
+            "Q12345",
+        ),
+        (
+            "orcid",
+            "Person",
+            "doesn't exist gs871s9j91k*",
+            "Lars",
+        ),
+    ],
+    ids=["ldap", "wikidata", "orcid"],
+)
 @pytest.mark.integration
 @pytest.mark.external
-def test_wikidata_search_and_ingest_results(ingest_page: Page) -> None:
+def test_search_and_ingest_roundtrip(
+    ingest_page: Page,
+    aux_provider: str,
+    stem_type: str,
+    invalid_search: str,
+    valid_search: str,
+) -> None:
     page = ingest_page
-    page = ingest_page
-    wikidata_tab = page.get_by_role("tab", name="wikidata")
-    expect(wikidata_tab).to_be_enabled(timeout=30)
-    wikidata_tab.click()
 
-    search_input = page.get_by_placeholder("Search here...")
-    expect(search_input).to_be_enabled(timeout=30)
-
-    # test search input is showing correctly
-    search_input.fill("Q000000")  # does not exist
-    search_input.press("Enter")
-    heading = page.get_by_test_id("search-results-heading")
-    expect(heading).to_be_visible()
-    page.screenshot(path="tests_ingest_test_main-test_search-input-0-found.png")
-    expect(page.get_by_text("Showing 0 of 0 items")).to_be_visible()
-
-    # test expand button works
-    search_input.fill("Q12345")
-    search_input.press("Enter")
-    expand_all_properties_button = page.get_by_test_id("expand-properties-button-0")
-    page.screenshot(path="tests_ingest_test_main-search_result.png")
-    expect(page.get_by_text("Count von Count")).to_be_visible()
-    expect(page.get_by_test_id("all-properties-display")).not_to_be_visible()
-    expand_all_properties_button.click()
-    expect(page.get_by_test_id("all-properties-display")).to_be_visible()
-    page.screenshot(path="tests_ingest_test_main-test_expand_button.png")
-
-    # test ingest button works
-    ingest_button = page.get_by_test_id("ingest-button-0")
-    ingest_button.click()
-    toast = page.locator(".editor-toast").first
-    expect(toast).to_be_visible()
-    expect(toast).to_contain_text("Organization was ingested successfully.")
-    expect(ingest_button).to_be_disabled()
-    page.screenshot(path="tests_ingest_test_main-test_ingest_button.png")
-
-    # test node was ingested into backend
+    # count the items before
     connector = BackendApiConnector.get()
-    result = connector.fetch_extracted_items("Count von Count", None, None, 0, 1)
-    assert result.total >= 1
+    result = connector.fetch_extracted_items(
+        None, None, [f"Extracted{stem_type}"], 0, 1
+    )
+    items_before = result.total
 
-
-@pytest.mark.integration
-@pytest.mark.external
-def test_ldap_search_and_ingest_results(ingest_page: Page) -> None:
-    # count the persons before
-    connector = BackendApiConnector.get()
-    result = connector.fetch_extracted_items(None, None, ["ExtractedPerson"], 0, 1)
-    persons_before = result.total
-
-    page = ingest_page
-    ldap_tab = page.get_by_role("tab", name="LDAP")
-    expect(ldap_tab).to_be_enabled(timeout=30)
+    # go to the correct tab
+    ldap_tab = page.get_by_role("tab", name=aux_provider)
+    expect(ldap_tab).to_be_enabled(timeout=30000)
     ldap_tab.click()
-
     search_input = page.get_by_placeholder("Search here...")
     expect(search_input).to_be_visible()
+    expect(search_input).to_be_enabled()
 
     # test search input is showing correctly
-    search_input.fill("doesn't exist gs871s9j91k*")
+    search_input.fill(invalid_search)
     search_input.press("Enter")
-    page.screenshot(path="tests_ingest_test_main-test_ldap_search-input-0-found.png")
+    page.screenshot(
+        path=f"tests_ingest_test_main-roundtrip_{aux_provider}-invalid-search.png"
+    )
     expect(page.get_by_text("Showing 0 of")).to_be_visible()
 
-    # test expand button works
-    search_input.fill("L*")
+    # trigger valid search
+    search_input.fill(valid_search)
     search_input.press("Enter")
-    expand_all_properties_button = page.get_by_test_id("expand-properties-button-0")
-    page.screenshot(path="tests_ingest_test_main-search_result_lap.png")
+    page.screenshot(
+        path=f"tests_ingest_test_main-roundtrip_{aux_provider}-valid-search.png"
+    )
+    expect(search_input).to_be_enabled()
+
+    # test expand button works
+    expand_button = page.get_by_test_id("expand-properties-button-0")
+    expect(expand_button).to_be_visible()
+
+    page.screenshot(path=f"tests_ingest_test_main-roundtrip_{aux_provider}.png")
     expect(page.get_by_test_id("all-properties-display")).not_to_be_visible()
-    expand_all_properties_button.click()
+    expand_button.click()
     expect(page.get_by_test_id("all-properties-display")).to_be_visible()
-    page.screenshot(path="tests_ingest_test_main-test_ldap_expand_button.png")
+    page.screenshot(
+        path=f"tests_ingest_test_main-roundtrip_{aux_provider}-expanded.png"
+    )
 
     # test ingest button works
     ingest_button = page.get_by_test_id("ingest-button-0")
     ingest_button.click()
     toast = page.locator(".editor-toast").first
     expect(toast).to_be_visible()
-    expect(toast).to_contain_text("Person was ingested successfully.")
+    expect(toast).to_contain_text(f"{stem_type} was ingested successfully.")
     expect(ingest_button).to_be_disabled()
-    page.screenshot(path="tests_ingest_test_main-test_ldap_ingest_button.png")
+    page.screenshot(
+        path=f"tests_ingest_test_main-roundtrip_{aux_provider}-imported.png"
+    )
 
-    # count the persons after
-    result = connector.fetch_extracted_items(None, None, ["ExtractedPerson"], 0, 1)
-    assert result.total == persons_before + 1
-
-
-@pytest.mark.integration
-@pytest.mark.external
-def test_orcid_search_and_ingest_results(ingest_page: Page) -> None:
-    page = ingest_page
-    orcid_tab = page.get_by_role("tab", name="Orcid")
-    expect(orcid_tab).to_be_enabled(timeout=30)
-    orcid_tab.click()
-    search_input = page.get_by_placeholder("Search here...")
-    expect(search_input).to_be_visible()
-
-    # test search input is showing correctly
-    search_input.fill("doesn't exist gs871s9j91k*")
-    pagination_page_select = page.get_by_test_id("pagination-page-select")
-    expect(pagination_page_select).to_be_visible()
-    page.screenshot(path="tests_ingest_test_main-test_orcid_search-input-0-found.png")
-    expect(page.get_by_text("Showing 0 of 0")).to_be_visible()
-
-    # test expand button works
-    search_input.fill("Lars")
-    page.screenshot(path="tests_ingest_test_main-search_result_orcid.png")
-    expand_all_properties_button = page.get_by_test_id("expand-properties-button-1")
-    expect(page.get_by_text("Lars")).to_be_visible()
-    expect(page.get_by_test_id("all-properties-display")).not_to_be_visible()
-    expand_all_properties_button.click()
-    expect(page.get_by_test_id("all-properties-display")).to_be_visible()
-    page.screenshot(path="tests_ingest_test_main-test_orcid_expand_button.png")
-
-    # test ingest button works
-    ingest_button = page.get_by_test_id("ingest-button-1")
-    ingest_button.click()
-    expect(page.get_by_text("Person was ingested successfully")).to_be_visible()
-    expect(ingest_button).to_be_disabled()
-    page.screenshot(path="tests_ingest_test_main-test_orcid_ingest_button.png")
-
-    # test node was ingested into backend
-    connector = BackendApiConnector.get()
-    result = connector.fetch_extracted_items("Lars", None, None, 0, 1)
-    assert result.total >= 1
+    # count the items afterwards
+    result = connector.fetch_extracted_items(
+        None, None, [f"Extracted{stem_type}"], 0, 1
+    )
+    assert result.total == items_before + 1
 
 
 @pytest.mark.external
 @pytest.mark.integration
-def test_pagination(ingest_page: Page) -> None:
+def test_pagination_on_ldap_tab(ingest_page: Page) -> None:
     page = ingest_page
     search_input = page.get_by_placeholder("Search here...")
     expect(search_input).to_be_enabled()
@@ -166,8 +130,7 @@ def test_pagination(ingest_page: Page) -> None:
     pagination_previous = page.get_by_test_id("pagination-previous-button")
     pagination_next = page.get_by_test_id("pagination-next-button")
     pagination_page_select = page.get_by_test_id("pagination-page-select")
-    expect(pagination_page_select).to_be_visible(timeout=30)
-    page.screenshot(path="tests_ingest_test_main-test_pagination.png")
+    page.screenshot(path="tests_ingest_test_main-test_pagination_on_ldap_tab.png")
     expect(pagination_previous).to_be_disabled()
     expect(pagination_next).to_be_disabled()
     expect(pagination_page_select).to_be_disabled()

--- a/tests/ingest/test_main.py
+++ b/tests/ingest/test_main.py
@@ -63,12 +63,13 @@ def test_search_and_ingest_roundtrip(
     result = connector.fetch_extracted_items(
         None, None, [f"Extracted{stem_type}"], 0, 1
     )
+    assert result.total == 0
     items_before = result.total
 
     # go to the correct tab
-    ldap_tab = page.get_by_role("tab", name=aux_provider)
-    expect(ldap_tab).to_be_enabled(timeout=30000)
-    ldap_tab.click()
+    aux_provider_tab = page.get_by_role("tab", name=aux_provider)
+    expect(aux_provider_tab).to_be_enabled(timeout=30000)
+    aux_provider_tab.click()
     search_input = page.get_by_placeholder("Search here...")
     expect(search_input).to_be_visible()
     expect(search_input).to_be_enabled()
@@ -96,7 +97,7 @@ def test_search_and_ingest_roundtrip(
 
     # test pagination is showing
     prev_button = page.get_by_test_id("pagination-previous-button")
-    expect(prev_button).to_be_disabled()
+    expect(prev_button).to_be_disabled(timeout=30000)
     expect(page.get_by_test_id("pagination-next-button")).to_be_visible()
     expect(page.get_by_test_id("pagination-page-select")).to_be_visible()
 
@@ -127,7 +128,7 @@ def test_search_and_ingest_roundtrip(
     result = connector.fetch_extracted_items(
         None, None, [f"Extracted{stem_type}"], 0, 1
     )
-    assert result.total >= items_before
+    assert result.total > items_before
 
 
 @pytest.mark.integration

--- a/tests/ingest/test_main.py
+++ b/tests/ingest/test_main.py
@@ -26,19 +26,26 @@ def test_aux_tab_section(ingest_page: Page) -> None:
 @pytest.mark.external
 def test_wikidata_search_and_ingest_results(ingest_page: Page) -> None:
     page = ingest_page
+    page = ingest_page
+    wikidata_tab = page.get_by_role("tab", name="wikidata")
+    expect(wikidata_tab).to_be_enabled(timeout=30)
+    wikidata_tab.click()
+
     search_input = page.get_by_placeholder("Search here...")
-    expect(search_input).to_be_visible()
+    expect(search_input).to_be_enabled(timeout=30)
 
     # test search input is showing correctly
     search_input.fill("Q000000")  # does not exist
     search_input.press("Enter")
+    heading = page.get_by_test_id("search-results-heading")
+    expect(heading).to_be_visible()
     page.screenshot(path="tests_ingest_test_main-test_search-input-0-found.png")
-    expect(page.get_by_text("showing 0 of")).to_be_visible()
+    expect(page.get_by_text("Showing 0 of 0 items")).to_be_visible()
 
     # test expand button works
     search_input.fill("Q12345")
     search_input.press("Enter")
-    expand_all_properties_button = page.get_by_test_id("expand-properties-button").first
+    expand_all_properties_button = page.get_by_test_id("expand-properties-button-0")
     page.screenshot(path="tests_ingest_test_main-search_result.png")
     expect(page.get_by_text("Count von Count")).to_be_visible()
     expect(page.get_by_test_id("all-properties-display")).not_to_be_visible()
@@ -47,7 +54,7 @@ def test_wikidata_search_and_ingest_results(ingest_page: Page) -> None:
     page.screenshot(path="tests_ingest_test_main-test_expand_button.png")
 
     # test ingest button works
-    ingest_button = page.get_by_text("Ingest").first
+    ingest_button = page.get_by_test_id("ingest-button-0")
     ingest_button.click()
     toast = page.locator(".editor-toast").first
     expect(toast).to_be_visible()
@@ -71,7 +78,9 @@ def test_ldap_search_and_ingest_results(ingest_page: Page) -> None:
 
     page = ingest_page
     ldap_tab = page.get_by_role("tab", name="LDAP")
+    expect(ldap_tab).to_be_enabled(timeout=30)
     ldap_tab.click()
+
     search_input = page.get_by_placeholder("Search here...")
     expect(search_input).to_be_visible()
 
@@ -84,7 +93,7 @@ def test_ldap_search_and_ingest_results(ingest_page: Page) -> None:
     # test expand button works
     search_input.fill("L*")
     search_input.press("Enter")
-    expand_all_properties_button = page.get_by_test_id("expand-properties-button").first
+    expand_all_properties_button = page.get_by_test_id("expand-properties-button-0")
     page.screenshot(path="tests_ingest_test_main-search_result_lap.png")
     expect(page.get_by_test_id("all-properties-display")).not_to_be_visible()
     expand_all_properties_button.click()
@@ -92,7 +101,7 @@ def test_ldap_search_and_ingest_results(ingest_page: Page) -> None:
     page.screenshot(path="tests_ingest_test_main-test_ldap_expand_button.png")
 
     # test ingest button works
-    ingest_button = page.get_by_text("Ingest").first
+    ingest_button = page.get_by_test_id("ingest-button-0")
     ingest_button.click()
     toast = page.locator(".editor-toast").first
     expect(toast).to_be_visible()
@@ -110,21 +119,22 @@ def test_ldap_search_and_ingest_results(ingest_page: Page) -> None:
 def test_orcid_search_and_ingest_results(ingest_page: Page) -> None:
     page = ingest_page
     orcid_tab = page.get_by_role("tab", name="Orcid")
+    expect(orcid_tab).to_be_enabled(timeout=30)
     orcid_tab.click()
     search_input = page.get_by_placeholder("Search here...")
     expect(search_input).to_be_visible()
 
     # test search input is showing correctly
     search_input.fill("doesn't exist gs871s9j91k*")
+    pagination_page_select = page.get_by_test_id("pagination-page-select")
+    expect(pagination_page_select).to_be_visible()
     page.screenshot(path="tests_ingest_test_main-test_orcid_search-input-0-found.png")
-    expect(page.get_by_text("Showing 0 of")).to_be_visible()
+    expect(page.get_by_text("Showing 0 of 0")).to_be_visible()
 
     # test expand button works
     search_input.fill("Lars")
     page.screenshot(path="tests_ingest_test_main-search_result_orcid.png")
-    expand_all_properties_button = page.get_by_test_id("expand-properties-button").nth(
-        1
-    )
+    expand_all_properties_button = page.get_by_test_id("expand-properties-button-1")
     expect(page.get_by_text("Lars")).to_be_visible()
     expect(page.get_by_test_id("all-properties-display")).not_to_be_visible()
     expand_all_properties_button.click()
@@ -132,7 +142,7 @@ def test_orcid_search_and_ingest_results(ingest_page: Page) -> None:
     page.screenshot(path="tests_ingest_test_main-test_orcid_expand_button.png")
 
     # test ingest button works
-    ingest_button = page.get_by_text("Ingest").nth(1)
+    ingest_button = page.get_by_test_id("ingest-button-1")
     ingest_button.click()
     expect(page.get_by_text("Person was ingested successfully")).to_be_visible()
     expect(ingest_button).to_be_disabled()
@@ -144,18 +154,20 @@ def test_orcid_search_and_ingest_results(ingest_page: Page) -> None:
     assert result.total >= 1
 
 
+@pytest.mark.external
 @pytest.mark.integration
 def test_pagination(ingest_page: Page) -> None:
     page = ingest_page
     search_input = page.get_by_placeholder("Search here...")
-    expect(search_input).to_be_visible()
+    expect(search_input).to_be_enabled()
     search_input.fill("no such results")
 
     # test pagination is showing and properly disabled
-    page.screenshot(path="tests_ingest_test_main-test_pagination.png")
     pagination_previous = page.get_by_test_id("pagination-previous-button")
     pagination_next = page.get_by_test_id("pagination-next-button")
     pagination_page_select = page.get_by_test_id("pagination-page-select")
+    expect(pagination_page_select).to_be_visible(timeout=30)
+    page.screenshot(path="tests_ingest_test_main-test_pagination.png")
     expect(pagination_previous).to_be_disabled()
     expect(pagination_next).to_be_disabled()
-    assert pagination_page_select.inner_text() == ""
+    expect(pagination_page_select).to_be_disabled()

--- a/tests/rules/test_state.py
+++ b/tests/rules/test_state.py
@@ -39,6 +39,7 @@ def test_state_get_primary_sources_by_field_name() -> None:
             identifier="somePrimarySource",
             input_config=InputConfig(),
             editor_values=[EditorValue(text="test@foo.bar")],
+            enabled=True,
         ),
         EditorPrimarySource(
             name=EditorValue(
@@ -47,5 +48,7 @@ def test_state_get_primary_sources_by_field_name() -> None:
             ),
             identifier="00000000000000",
             input_config=InputConfig(editable_text=True, allow_additive=True),
+            editor_values=[],
+            enabled=True,
         ),
     ]

--- a/tests/rules/test_transform.py
+++ b/tests/rules/test_transform.py
@@ -395,8 +395,8 @@ def test_transform_model_to_input_config(
                     ),
                     identifier=MergedPrimarySourceIdentifier("primarySourceId"),
                     editor_values=[EditorValue(text="Family")],
-                    enabled=False,
                     input_config=InputConfig(),
+                    enabled=False,
                 )
             ],
         ),

--- a/tests/rules/test_transform.py
+++ b/tests/rules/test_transform.py
@@ -569,6 +569,7 @@ def test_transform_models_to_fields() -> None:
                     EditorPrimarySource(
                         enabled=True,
                         input_config=InputConfig(),
+                        editor_values=[],
                         name=EditorValue(text="No Input Config"),
                         identifier=MergedPrimarySourceIdentifier("PrimarySource000000"),
                     )
@@ -615,6 +616,7 @@ def test_transform_fields_to_additive(
                     EditorPrimarySource(
                         enabled=True,
                         input_config=InputConfig(),
+                        editor_values=[],
                         name=EditorValue(text="Enabled Primary Source"),
                         identifier=MergedPrimarySourceIdentifier(
                             "enabledPrimarySourceId"
@@ -632,6 +634,7 @@ def test_transform_fields_to_additive(
                     EditorPrimarySource(
                         enabled=True,
                         input_config=InputConfig(),
+                        editor_values=[],
                         name=EditorValue(text="Enabled Primary Source"),
                         identifier=MergedPrimarySourceIdentifier(
                             "enabledPrimarySourceId"
@@ -640,6 +643,7 @@ def test_transform_fields_to_additive(
                     EditorPrimarySource(
                         enabled=False,
                         input_config=InputConfig(),
+                        editor_values=[],
                         name=EditorValue(text="Prevented Primary Source"),
                         identifier=MergedPrimarySourceIdentifier(
                             "preventedPrimarySourceId"
@@ -747,6 +751,7 @@ def test_transform_editor_value_to_model_value(
                     EditorPrimarySource(
                         name=EditorValue(text="Primary Source 1"),
                         identifier=MergedPrimarySourceIdentifier("PrimarySource001"),
+                        editor_values=[],
                         input_config=InputConfig(),
                         enabled=True,
                     )
@@ -803,12 +808,14 @@ def test_transform_fields_to_rule_set() -> None:
                     EditorPrimarySource(
                         name=EditorValue(text="Enabled Primary Source"),
                         identifier=MergedPrimarySourceIdentifier("PrimarySource001"),
+                        editor_values=[],
                         input_config=InputConfig(),
                         enabled=True,
                     ),
                     EditorPrimarySource(
                         name=EditorValue(text="Prevented Primary Source"),
                         identifier=MergedPrimarySourceIdentifier("PrimarySource002"),
+                        editor_values=[],
                         enabled=False,
                         input_config=InputConfig(),
                     ),

--- a/tests/rules/test_transform.py
+++ b/tests/rules/test_transform.py
@@ -350,6 +350,7 @@ def test_transform_model_to_input_config(
                         href="/item/primarySourceId",
                     ),
                     identifier=MergedPrimarySourceIdentifier("primarySourceId"),
+                    editor_values=[],
                     input_config=InputConfig(),
                     enabled=True,
                 )

--- a/tests/search/test_main.py
+++ b/tests/search/test_main.py
@@ -204,7 +204,7 @@ def test_push_search_params(
 
     # load page and verify url
     page.goto(frontend_url)
-    page.wait_for_url("**/", timeout=10)
+    page.wait_for_url("**/", timeout=10000)
 
     # select an entity type
     entity_types = page.get_by_test_id("entity-types")

--- a/tests/search/test_main.py
+++ b/tests/search/test_main.py
@@ -55,7 +55,7 @@ def test_pagination(
     pagination_page_select = page.get_by_test_id("pagination-page-select")
     expect(pagination_previous).to_be_disabled()
     expect(pagination_next).to_be_disabled()
-    assert pagination_page_select.inner_text() == "1"
+    expect(pagination_page_select).to_be_disabled()
 
 
 @pytest.mark.integration

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -77,5 +77,5 @@ def test_state_check_login_fail() -> None:
 def test_update_raw_path(
     nav_item: NavItem, params: dict[str, Any], expected: str
 ) -> None:
-    State._update_raw_path(nav_item, **params)
+    State._update_raw_path(nav_item, params)
     assert nav_item.raw_path == expected

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -135,8 +135,8 @@ def test_transform_models_to_preview(dummy_data: list[AnyExtractedModel]) -> Non
     assert dummy_previews == [
         [EditorValue(text="PrimarySource")],
         [EditorValue(text="PrimarySource")],
-        [EditorValue(text="ContactPoint")],
-        [EditorValue(text="ContactPoint")],
+        [EditorValue(text="info@contact-point.one")],
+        [EditorValue(text="help@contact-point.two")],
         [EditorValue(text="Unit 1", badge="EN", enabled=True)],
         [
             EditorValue(text="A1", enabled=True),


### PR DESCRIPTION
### Changes

- prep reflex update:
  - avoid byte operators on Vars, use rx.cond instead
  - avoid Var.to_string(), use f-strings to render vars instead
  - avoid magical setters/getters on State, implement them explicitly
  - avoid calling event handlers from other event handlers, use private methods / direct assignments instead
  - avoid kwargs on event handlers, use positional Mapping argument instead
  - avoid getting granian warnings, set env var explicitly
  - avoid defaults for state model fields, making a swap to dataclasses easier
- fix some typing
- de-duplicate pagination component
- de-duplicate ingestion roundtrip tests
