### PR TITLE
feature/mx-1963 adds "None" to language selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- 'None' as language selection for `Link` and `Text`
+
 ### Changes
 
 ### Deprecated

--- a/mex/editor/models.py
+++ b/mex/editor/models.py
@@ -48,3 +48,4 @@ class ModelConfig(BaseModel):
 MODEL_CONFIG_BY_STEM_TYPE = TypeAdapter(dict[str, ModelConfig]).validate_python(
     yaml.safe_load(files("mex.editor").joinpath("models.yaml").open())
 )
+LANGUAGE_VALUE_NONE = "None"

--- a/mex/editor/rules/transform.py
+++ b/mex/editor/rules/transform.py
@@ -42,7 +42,11 @@ from mex.editor.fields import (
     REQUIRED_FIELDS_BY_CLASS_NAME,
     TEMPORAL_PRECISIONS_BY_FIELD_BY_CLASS_NAMES,
 )
-from mex.editor.models import MODEL_CONFIG_BY_STEM_TYPE, EditorValue
+from mex.editor.models import (
+    LANGUAGE_VALUE_NONE,
+    MODEL_CONFIG_BY_STEM_TYPE,
+    EditorValue,
+)
 from mex.editor.rules.models import (
     EditorField,
     EditorPrimarySource,
@@ -129,7 +133,7 @@ def _transform_model_to_input_config(  # noqa: PLR0911
             editable_text=editable,
             editable_badge=editable,
             badge_default=TextLanguage.DE.name,
-            badge_options=[e.name for e in TextLanguage],
+            badge_options=[e.name for e in TextLanguage] + [LANGUAGE_VALUE_NONE],
             badge_titles=[TextLanguage.__name__],
             allow_additive=editable,
         )
@@ -139,7 +143,7 @@ def _transform_model_to_input_config(  # noqa: PLR0911
             editable_badge=editable,
             editable_href=editable,
             badge_default=LinkLanguage.DE.name,
-            badge_options=[e.name for e in LinkLanguage],
+            badge_options=[e.name for e in LinkLanguage] + [LANGUAGE_VALUE_NONE],
             badge_titles=[LinkLanguage.__name__],
             allow_additive=editable,
         )
@@ -337,12 +341,16 @@ def _transform_editor_value_to_model_value(
     if field_name in LINK_FIELDS_BY_CLASS_NAME[class_name]:
         return Link(
             url=value.href,
-            language=LinkLanguage[value.badge] if value.badge else None,
+            language=LinkLanguage[value.badge]
+            if value.badge and value.badge != LANGUAGE_VALUE_NONE
+            else None,
             title=value.text,
         )
     if field_name in TEXT_FIELDS_BY_CLASS_NAME[class_name]:
         return Text(
-            language=TextLanguage[value.badge] if value.badge else None,
+            language=TextLanguage[value.badge]
+            if value.badge and value.badge != LANGUAGE_VALUE_NONE
+            else None,
             value=value.text,
         )
     if field_name in VOCABULARY_FIELDS_BY_CLASS_NAME[class_name]:

--- a/mex/editor/transform.py
+++ b/mex/editor/transform.py
@@ -7,7 +7,11 @@ from mex.common.models import (
     AnyRuleModel,
 )
 from mex.common.types import Identifier, Link, TemporalEntity, Text, VocabularyEnum
-from mex.editor.models import MODEL_CONFIG_BY_STEM_TYPE, EditorValue
+from mex.editor.models import (
+    LANGUAGE_VALUE_NONE,
+    MODEL_CONFIG_BY_STEM_TYPE,
+    EditorValue,
+)
 
 
 def ensure_list(values: object) -> list[object]:
@@ -35,13 +39,13 @@ def transform_value(
     if isinstance(value, Text):
         return EditorValue(
             text=value.value,
-            badge=value.language.name if value.language else None,
+            badge=value.language.name if value.language else LANGUAGE_VALUE_NONE,
         )
     if isinstance(value, Link):
         return EditorValue(
             text=value.title,
             href=value.url if allow_link else None,
-            badge=value.language.name if value.language else None,
+            badge=value.language.name if value.language else LANGUAGE_VALUE_NONE,
             external=True,
         )
     if isinstance(value, Identifier):

--- a/tests/rules/test_transform.py
+++ b/tests/rules/test_transform.py
@@ -43,7 +43,7 @@ from mex.common.types import (
     Year,
     YearMonthDayTime,
 )
-from mex.editor.models import EditorValue
+from mex.editor.models import LANGUAGE_VALUE_NONE, EditorValue
 from mex.editor.rules.models import (
     EditorField,
     EditorPrimarySource,
@@ -673,6 +673,12 @@ def test_transform_fields_to_preventive(
             Text(language=TextLanguage.DE, value="Beispiel Text"),
         ),
         (
+            EditorValue(text="Text", badge=LANGUAGE_VALUE_NONE),
+            "alternativeTitle",
+            "AdditivePrimarySource",
+            Text(language=None, value="Text"),
+        ),
+        (
             EditorValue(text="ConsentStatus", badge="EXPRESSED_CONSENT"),
             "hasConsentType",
             "AdditiveConsent",
@@ -712,6 +718,7 @@ def test_transform_fields_to_preventive(
     ids=[
         "link",
         "text",
+        "textNoneLang",
         "vocab",
         "default_vocab",
         "temporal",

--- a/tests/rules/test_transform.py
+++ b/tests/rules/test_transform.py
@@ -182,8 +182,7 @@ def test_get_primary_source_id_from_model_error() -> None:
                     enabled=False,
                 ),
                 EditorValue(
-                    href="http://pavyzdys",
-                    external=True,
+                    href="http://pavyzdys", external=True, badge=LANGUAGE_VALUE_NONE
                 ),
             ],
         ),
@@ -270,7 +269,7 @@ def test_transform_model_values_to_editor_values(
             "AdditiveResource",
             "documentation",
             InputConfig(
-                badge_options=["DE", "EN"],
+                badge_options=["DE", "EN", LANGUAGE_VALUE_NONE],
                 badge_default="DE",
                 badge_titles=["LinkLanguage"],
                 editable_href=True,
@@ -284,7 +283,7 @@ def test_transform_model_values_to_editor_values(
             "AdditiveResource",
             "keyword",
             InputConfig(
-                badge_options=["DE", "EN"],
+                badge_options=["DE", "EN", LANGUAGE_VALUE_NONE],
                 badge_default="DE",
                 badge_titles=["TextLanguage"],
                 editable_badge=True,

--- a/tests/search/test_transform.py
+++ b/tests/search/test_transform.py
@@ -1,5 +1,6 @@
 from mex.common.models import PreviewOrganizationalUnit
 from mex.common.types import Text, TextLanguage
+from mex.editor.models import LANGUAGE_VALUE_NONE
 from mex.editor.search.transform import transform_models_to_results
 
 
@@ -20,7 +21,7 @@ def test_transform_models_to_results() -> None:
         "title": [
             {
                 "text": "OU1",
-                "badge": None,
+                "badge": LANGUAGE_VALUE_NONE,
                 "being_edited": False,
                 "href": None,
                 "identifier": None,

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -112,7 +112,7 @@ def test_transform_models_to_title(dummy_data: list[AnyExtractedModel]) -> None:
         ],
         [
             # unit renders shortName as text (no language badge)
-            EditorValue(text="OU1")
+            EditorValue(text="OU1", badge=LANGUAGE_VALUE_NONE)
         ],
         [
             # activity renders title as text (with language badge)
@@ -120,7 +120,7 @@ def test_transform_models_to_title(dummy_data: list[AnyExtractedModel]) -> None:
         ],
         [
             # resource renders title as text
-            EditorValue(text="Bioinformatics Resource 1"),
+            EditorValue(text="Bioinformatics Resource 1", badge=LANGUAGE_VALUE_NONE),
         ],
     ]
 
@@ -144,7 +144,7 @@ def test_transform_models_to_preview(dummy_data: list[AnyExtractedModel]) -> Non
         [EditorValue(text="ContactPoint")],
         [EditorValue(text="Unit 1", badge="EN", enabled=True)],
         [
-            EditorValue(text="A1", enabled=True),
+            EditorValue(text="A1", enabled=True, badge=LANGUAGE_VALUE_NONE),
             EditorValue(identifier="wEvxYRPlmGVQCbZx9GAbn"),
             EditorValue(identifier="g32qzYNVH1Ez7JTEk3fvLF"),
             EditorValue(identifier="cWWm02l1c6cucKjIhkFqY4"),

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -2,7 +2,7 @@ import pytest
 
 from mex.common.models import AdditiveContactPoint, AnyExtractedModel
 from mex.common.types import APIType, Identifier, Link, LinkLanguage, Text, TextLanguage
-from mex.editor.models import EditorValue
+from mex.editor.models import LANGUAGE_VALUE_NONE, EditorValue
 from mex.editor.transform import (
     transform_models_to_preview,
     transform_models_to_stem_type,
@@ -20,6 +20,11 @@ from mex.editor.transform import (
             "foo",
             True,
             [EditorValue(text="foo")],
+        ),
+        (
+            Text(value="Text", language=None),
+            True,
+            [EditorValue(text="Text", badge=LANGUAGE_VALUE_NONE)],
         ),
         (
             [


### PR DESCRIPTION
### PR Context
<!-- Additional info for the reviewer -->

### Added
<!-- New features and interfaces -->
- 'None' as language selection for `Link` and `Text`

### Changes
<!-- Changes in existing functionality -->

### Deprecated
<!-- Soon-to-be removed features -->

### Removed
<!-- Definitely removed features -->

### Fixed
<!-- Fixed bugs -->

### Security
<!-- Fixed vulnerabilities -->
