### PR TITLE
feature/mx-1971-temporal-field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
 - infobox to ingest page for "ldap" and "wikidata"
 - new type for aux_provider instead of str
-
 - 'None' as language selection for `Link` and `Text`
+- add string input mask for `Resource.temporal` field
 
 ### Changes
+
 - type of aux provider from `str` to `AuxProvider`
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- remove edit toggle button for non-identifier fields
+
 ### Fixed
 
 - fix service readiness checks
+- use more of the available space for rule input fields
 
 ### Security
 

--- a/mex/editor/rules/main.py
+++ b/mex/editor/rules/main.py
@@ -58,7 +58,9 @@ def editor_edit_button(
             RuleState.resolve_identifiers,
         ],
         custom_attrs={
-            "data-testid": f"button-{field_name}-{primary_source.identifier}-{index}"
+            "data-testid": (
+                f"edit-toggle-{field_name}-{primary_source.identifier}-{index}"
+            )
         },
     )
 
@@ -89,22 +91,30 @@ def editor_additive_value(
 ) -> rx.Component:
     """Render an additive value with buttons for editing and removal."""
     return rx.hstack(
-        rx.cond(
-            value.being_edited,
-            additive_rule_input(
-                field_name,
-                primary_source.input_config,
-                index,
-                value,
+        rx.hstack(
+            rx.cond(
+                value.being_edited,
+                additive_rule_input(
+                    field_name,
+                    primary_source.input_config,
+                    index,
+                    value,
+                ),
+                render_value(value),
             ),
-            render_value(value),
+            rx.cond(
+                primary_source.input_config.editable_identifier,
+                editor_edit_button(field_name, primary_source, value, index),
+            ),
+            width="100%",
         ),
-        editor_edit_button(field_name, primary_source, value, index),
         remove_additive_button(
             field_name,
             index,
         ),
         custom_attrs={"data-testid": f"additive-rule-{field_name}-{index}"},
+        spacing="8",
+        width="100%",
     )
 
 
@@ -142,7 +152,7 @@ def href_input(
         on_change=RuleState.set_href_value(field_name, index),
         style={
             "margin": "calc(-1 * var(--space-1))",
-            "minWidth": "30%",
+            "width": "100%",
         },
         custom_attrs={"data-testid": f"additive-rule-{field_name}-{index}-href"},
     )
@@ -160,7 +170,7 @@ def text_input(
         on_change=RuleState.set_text_value(field_name, index),
         style={
             "margin": "calc(-1 * var(--space-1))",
-            "minWidth": "30%",
+            "width": "100%",
         },
         custom_attrs={"data-testid": f"additive-rule-{field_name}-{index}-text"},
     )
@@ -212,7 +222,7 @@ def additive_rule_input(
                 on_change=RuleState.set_href_value(field_name, index),
                 style={
                     "margin": "calc(-1 * var(--space-1))",
-                    "minWidth": "30%",
+                    "width": "100%",
                 },
                 custom_attrs={
                     "data-testid": f"additive-rule-{field_name}-{index}-href"
@@ -227,7 +237,7 @@ def additive_rule_input(
                 on_change=RuleState.set_text_value(field_name, index),
                 style={
                     "margin": "calc(-1 * var(--space-1))",
-                    "minWidth": "30%",
+                    "width": "100%",
                 },
                 custom_attrs={
                     "data-testid": f"additive-rule-{field_name}-{index}-text"
@@ -242,7 +252,7 @@ def additive_rule_input(
                 on_change=RuleState.set_identifier_value(field_name, index),
                 style={
                     "margin": "calc(-1 * var(--space-1))",
-                    "minWidth": "30%",
+                    "width": "100%",
                 },
                 custom_attrs={
                     "data-testid": f"additive-rule-{field_name}-{index}-identifier"
@@ -273,6 +283,7 @@ def additive_rule_input(
                 ),
             ),
         ),
+        width="100%",
     )
 
 

--- a/mex/editor/rules/transform.py
+++ b/mex/editor/rules/transform.py
@@ -98,11 +98,6 @@ def _transform_model_to_input_config(  # noqa: PLR0911
     editable: bool,  # noqa: FBT001
 ) -> InputConfig:
     """Determine the input type for a given field of a given model."""
-    if field_name in (MUTABLE_FIELDS_BY_CLASS_NAME[entity_type]):
-        return InputConfig(
-            editable_text=editable,
-            allow_additive=editable,
-        )
     if field_name in REFERENCE_FIELDS_BY_CLASS_NAME[entity_type]:
         return InputConfig(
             editable_identifier=editable,
@@ -149,6 +144,11 @@ def _transform_model_to_input_config(  # noqa: PLR0911
             badge_default=options[0].name,
             badge_options=[e.name for e in options],
             badge_titles=[v.__name__ for v in vocabularies],
+            allow_additive=editable,
+        )
+    if field_name in MUTABLE_FIELDS_BY_CLASS_NAME[entity_type]:
+        return InputConfig(
+            editable_text=editable,
             allow_additive=editable,
         )
     return InputConfig()

--- a/mex/editor/rules/transform.py
+++ b/mex/editor/rules/transform.py
@@ -5,12 +5,10 @@ from pydantic import ValidationError
 
 from mex.common.fields import (
     ALL_TYPES_BY_FIELDS_BY_CLASS_NAMES,
-    EMAIL_FIELDS_BY_CLASS_NAME,
-    INTEGER_FIELDS_BY_CLASS_NAME,
     LINK_FIELDS_BY_CLASS_NAME,
     MERGEABLE_FIELDS_BY_CLASS_NAME,
+    MUTABLE_FIELDS_BY_CLASS_NAME,
     REFERENCE_FIELDS_BY_CLASS_NAME,
-    STRING_FIELDS_BY_CLASS_NAME,
     TEMPORAL_FIELDS_BY_CLASS_NAME,
     TEXT_FIELDS_BY_CLASS_NAME,
     VOCABULARIES_BY_FIELDS_BY_CLASS_NAMES,
@@ -100,11 +98,7 @@ def _transform_model_to_input_config(  # noqa: PLR0911
     editable: bool,  # noqa: FBT001
 ) -> InputConfig:
     """Determine the input type for a given field of a given model."""
-    if field_name in (
-        STRING_FIELDS_BY_CLASS_NAME[entity_type]
-        + EMAIL_FIELDS_BY_CLASS_NAME[entity_type]  # stopgap: MX-1766
-        + INTEGER_FIELDS_BY_CLASS_NAME[entity_type]
-    ):
+    if field_name in (MUTABLE_FIELDS_BY_CLASS_NAME[entity_type]):
         return InputConfig(
             editable_text=editable,
             allow_additive=editable,

--- a/tests/api/test_main.py
+++ b/tests/api/test_main.py
@@ -19,7 +19,7 @@ def test_prometheus_metrics(client: TestClient) -> None:
     assert response.text == (
         """\
 # TYPE backend_api_identity_provider_cache_hits counter
-backend_api_identity_provider_cache_hits 18
+backend_api_identity_provider_cache_hits 17
 
 # TYPE backend_api_identity_provider_cache_misses counter
 backend_api_identity_provider_cache_misses 7"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -160,7 +160,6 @@ def dummy_data() -> list[AnyExtractedModel]:
         ],
         contact=[
             contact_point_1.stableTargetId,
-            contact_point_2.stableTargetId,
             organizational_unit_1.stableTargetId,
         ],
         hadPrimarySource=primary_source_1.stableTargetId,

--- a/tests/create/test_main.py
+++ b/tests/create/test_main.py
@@ -46,8 +46,9 @@ def test_create_page_renders_fields(create_page: Page) -> None:
     page.screenshot(
         path="tests_create_test_main-test_create_page_renders_fields_select.png"
     )
-    all_fields = page.get_by_role("row").all()
-    assert len(all_fields) == len(MERGEABLE_FIELDS_BY_CLASS_NAME["ExtractedResource"])
+    expect(page.get_by_role("row")).to_have_count(
+        len(MERGEABLE_FIELDS_BY_CLASS_NAME["ExtractedResource"])
+    )
 
 
 @pytest.mark.integration

--- a/tests/edit/test_main.py
+++ b/tests/edit/test_main.py
@@ -339,7 +339,7 @@ def test_edit_page_resolves_additive_identifier(
     identifier_input = page.get_by_test_id("additive-rule-involvedUnit-0-identifier")
     expect(identifier_input).to_be_visible()
     identifier_input.fill(organizational_unit.stableTargetId)
-    edit_button = page.get_by_test_id("button-involvedUnit-00000000000000-0")
+    edit_button = page.get_by_test_id("edit-toggle-involvedUnit-00000000000000-0")
     edit_button.click()
 
     # verify identifier is correctly rendered
@@ -471,7 +471,7 @@ def test_edit_page_additive_rule_roundtrip(edit_page: Page) -> None:
     expect(additive_rule_rendered).to_be_visible()
 
     # click edit button
-    edit_button = page.get_by_test_id("button-fundingProgram-00000000000000-0")
+    edit_button = page.get_by_test_id("edit-toggle-fundingProgram-00000000000000-0")
     edit_button.scroll_into_view_if_needed()
     page.screenshot(path=f"{test_id}-on_load.png")
     expect(edit_button).to_be_visible()

--- a/tests/edit/test_main.py
+++ b/tests/edit/test_main.py
@@ -158,7 +158,7 @@ def test_edit_page_resolves_identifier(
 ) -> None:
     page = edit_page
     extracted_organizational_unit = dummy_data_by_stable_target_id[
-        extracted_activity.contact[2]
+        extracted_activity.contact[1]
     ]
     assert type(extracted_organizational_unit) is ExtractedOrganizationalUnit
 
@@ -173,7 +173,7 @@ def test_edit_page_resolves_identifier(
     )  # resolved short name of unit
     expect(link).to_have_attribute(
         "href",
-        f"/item/{extracted_activity.contact[2]}/",  # link href
+        f"/item/{extracted_activity.contact[1]}/",  # link href
     )
     expect(link).not_to_have_attribute("target", "_blank")  # internal link
 

--- a/tests/edit/test_main.py
+++ b/tests/edit/test_main.py
@@ -427,24 +427,26 @@ def test_edit_page_renders_temporal_input(edit_page: Page) -> None:
 
 
 @pytest.mark.integration
-def test_edit_page_additive_rule_roundtrip(edit_page: Page) -> None:
+def test_edit_page_additive_rule_roundtrip(
+    edit_page: Page,
+    dummy_data_by_identifier_in_primary_source: dict[str, AnyExtractedModel],
+) -> None:
     page = edit_page
     test_id = "tests_edit_test_main-test_edit_page_additive_rule_roundtrip"
 
-    # click button for new additive rule on fundingProgram field
-    new_additive_button = page.get_by_test_id(
-        "new-additive-fundingProgram-00000000000000"
-    )
+    # click button for new additive rule on contact field
+    new_additive_button = page.get_by_test_id("new-additive-contact-00000000000000")
     new_additive_button.scroll_into_view_if_needed()
     page.screenshot(path=f"{test_id}-on_load.png")
     expect(new_additive_button).to_be_visible()
     new_additive_button.click()
 
     # fill a string into the additive rule input
-    input_id = "additive-rule-fundingProgram-0-text"
+    input_id = "additive-rule-contact-0-identifier"
     additive_rule_input = page.get_by_test_id(input_id)
     expect(additive_rule_input).to_be_visible()
-    rule_value = "FundEverything e.V."
+    contact_point_2 = dummy_data_by_identifier_in_primary_source["cp-2"]
+    rule_value = contact_point_2.stableTargetId
     additive_rule_input.fill(rule_value)
     page.screenshot(path=f"{test_id}-input-filled.png")
 
@@ -463,7 +465,7 @@ def test_edit_page_additive_rule_roundtrip(edit_page: Page) -> None:
     page.reload()
 
     # verify the state after first saving: additive rule is present
-    rendered_input_id = "additive-rule-fundingProgram-0"
+    rendered_input_id = "additive-rule-contact-0"
     additive_rule_rendered = page.get_by_test_id(rendered_input_id)
     expect(additive_rule_rendered).to_have_count(1)
     additive_rule_rendered.scroll_into_view_if_needed()
@@ -471,7 +473,7 @@ def test_edit_page_additive_rule_roundtrip(edit_page: Page) -> None:
     expect(additive_rule_rendered).to_be_visible()
 
     # click edit button
-    edit_button = page.get_by_test_id("edit-toggle-fundingProgram-00000000000000-0")
+    edit_button = page.get_by_test_id("edit-toggle-contact-00000000000000-0")
     edit_button.scroll_into_view_if_needed()
     page.screenshot(path=f"{test_id}-on_load.png")
     expect(edit_button).to_be_visible()
@@ -484,7 +486,7 @@ def test_edit_page_additive_rule_roundtrip(edit_page: Page) -> None:
 
     # now remove the additive rule for a full roundtrip
     remove_additive_rule_button = page.get_by_test_id(
-        "additive-rule-fundingProgram-0-remove-button"
+        "additive-rule-contact-0-remove-button"
     )
     expect(remove_additive_rule_button).to_be_visible()
     remove_additive_rule_button.click()
@@ -500,7 +502,7 @@ def test_edit_page_additive_rule_roundtrip(edit_page: Page) -> None:
     page.reload()
 
     # check the rule input is still gone
-    page.get_by_test_id("field-fundingProgram").scroll_into_view_if_needed()
+    page.get_by_test_id("field-contact").scroll_into_view_if_needed()
     page.screenshot(path=f"{test_id}-reload_2.png")
     additive_rule_rendered = page.get_by_test_id(rendered_input_id)
     expect(additive_rule_rendered).to_have_count(0)

--- a/tests/edit/test_main.py
+++ b/tests/edit/test_main.py
@@ -58,9 +58,8 @@ def test_edit_page_renders_fields(
     funding_program = page.get_by_test_id("field-fundingProgram-name")
     page.screenshot(path="tests_edit_test_main-test_edit_page_renders_fields.png")
     expect(funding_program).to_be_visible()
-    all_fields = page.get_by_role("row").all()
-    assert len(all_fields) == len(
-        MERGEABLE_FIELDS_BY_CLASS_NAME[extracted_activity.entityType]
+    expect(page.get_by_role("row")).to_have_count(
+        len(MERGEABLE_FIELDS_BY_CLASS_NAME[extracted_activity.entityType])
     )
 
 
@@ -356,7 +355,9 @@ def test_edit_page_resolves_additive_identifier(
     # assert raw identifier value is retained
     edit_button.click()
     identifier_input = page.get_by_test_id("additive-rule-involvedUnit-0-identifier")
-    assert identifier_input.get_attribute("value") == organizational_unit.stableTargetId
+    expect(identifier_input).to_have_attribute(
+        "value", organizational_unit.stableTargetId
+    )
 
 
 @pytest.mark.integration

--- a/tests/edit/test_main.py
+++ b/tests/edit/test_main.py
@@ -163,7 +163,7 @@ def test_edit_page_resolves_identifier(
     assert type(extracted_organizational_unit) is ExtractedOrganizationalUnit
 
     contact = page.get_by_test_id(
-        f"value-contact-{extracted_activity.hadPrimarySource}-2"
+        f"value-contact-{extracted_activity.hadPrimarySource}-1"
     )
     page.screenshot(path="tests_edit_test_main-test_edit_page_renders_identifier.png")
     expect(contact).to_be_visible()

--- a/tests/rules/test_transform.py
+++ b/tests/rules/test_transform.py
@@ -236,7 +236,16 @@ def test_transform_model_values_to_editor_values(
                 editable_text=True,
                 allow_additive=True,
             ),
-            id="temporal field",
+            id="temporal entity field",
+        ),
+        pytest.param(
+            "AdditiveResource",
+            "temporal",
+            InputConfig(
+                editable_text=True,
+                allow_additive=True,
+            ),
+            id="temporal or string field",
         ),
         pytest.param(
             "AdditiveContactPoint",

--- a/tests/search/test_main.py
+++ b/tests/search/test_main.py
@@ -55,7 +55,7 @@ def test_pagination(
     pagination_page_select = page.get_by_test_id("pagination-page-select")
     expect(pagination_previous).to_be_disabled()
     expect(pagination_next).to_be_disabled()
-    assert pagination_page_select.inner_text() == "1"
+    expect(pagination_page_select).to_have_text("1")
 
 
 @pytest.mark.integration

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -146,7 +146,6 @@ def test_transform_models_to_preview(dummy_data: list[AnyExtractedModel]) -> Non
         [
             EditorValue(text="A1", enabled=True, badge=LANGUAGE_VALUE_NONE),
             EditorValue(identifier="wEvxYRPlmGVQCbZx9GAbn"),
-            EditorValue(identifier="g32qzYNVH1Ez7JTEk3fvLF"),
             EditorValue(identifier="cWWm02l1c6cucKjIhkFqY4"),
             EditorValue(identifier="cWWm02l1c6cucKjIhkFqY4"),
             EditorValue(text="1999-12-24", badge="day"),


### PR DESCRIPTION
### PR Context

- removed 1 contact point from the test data activity, so we can test the edit toggle button with an actual reference field

### Added
- add string input mask for `Resource.temporal` field

### Removed

- remove edit toggle button for non-identifier fields

### Fixed

- use more of the available space for rule input fields
