### PR TITLE
feature/mx-1958 textareas for fields with long text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- added textareas for fields listed in mex/editor/models.yaml
 
 ### Changes
 

--- a/mex/editor/models.py
+++ b/mex/editor/models.py
@@ -42,6 +42,7 @@ class ModelConfig(BaseModel):
 
     title: str
     preview: list[str] = []
+    textarea: list[str] = []
 
 
 MODEL_CONFIG_BY_STEM_TYPE = TypeAdapter(dict[str, ModelConfig]).validate_python(

--- a/mex/editor/models.yaml
+++ b/mex/editor/models.yaml
@@ -13,6 +13,10 @@ Activity:
     - responsibleUnit
     - start
     - end
+  textarea:
+    - abstract
+    - alternativeTitle
+    - title
 BibliographicResource:
   title: title
   preview:
@@ -20,6 +24,13 @@ BibliographicResource:
     - publicationYear
     - creator
     - accessRestriction
+  textarea:
+    - abstract
+    - alternativeTitle
+    - subtitle
+    - title
+    - titleOfBook
+    - titleOfSeries
 Consent:
   title: isIndicatedAtTime
   preview:
@@ -35,12 +46,17 @@ Distribution:
     - mediaType
     - issued
     - accessRestriction
+  textarea:
+    - title
 Organization:
   title: officialName
   preview:
     - shortName
     - alternativeName
     - wikidataId
+  textarea:
+    - alternativeName
+    - officialName
 OrganizationalUnit:
   title: shortName
   preview:
@@ -58,6 +74,10 @@ PrimarySource:
   preview:
     - contact
     - unitInCharge
+  textarea:
+    - alternativeTitle
+    - description
+    - title
 Resource:
   title: title
   preview:
@@ -65,13 +85,31 @@ Resource:
     - theme
     - resourceCreationMethod
     - accessRestriction
+  textarea:
+    - alternativeTitle
+    - description
+    - hasLegalBasis
+    - hasPurpose
+    - instrumentToolOrApparatus
+    - methodDescription
+    - publicationCoverage
+    - provenance
+    - qualityInformation
+    - rights
+    - title
 Variable:
   title: label
   preview:
     - dataType
     - belongsTo
     - usedIn
+  textarea:
+    - description
+    - label
+    - valueSet
 VariableGroup:
   title: label
   preview:
     - containedBy
+  textarea:
+    - label

--- a/mex/editor/rules/main.py
+++ b/mex/editor/rules/main.py
@@ -234,17 +234,34 @@ def additive_rule_input(
         ),
         rx.cond(
             input_config.editable_text,
-            rx.input(
-                placeholder="Text",
-                value=value.text,
-                on_change=RuleState.set_text_value(field_name, index),
-                style={
-                    "margin": "calc(-1 * var(--space-1))",
-                    "width": "100%",
-                },
-                custom_attrs={
-                    "data-testid": f"additive-rule-{field_name}-{index}-text"
-                },
+            rx.cond(
+                input_config.render_textarea,
+                rx.text_area(
+                    placeholder="Text",
+                    value=value.text,
+                    on_change=RuleState.set_text_value(field_name, index),
+                    style={
+                        "margin": "calc(-1 * var(--space-1))",
+                        "width": "100%",
+                    },
+                    custom_attrs={
+                        "data-testid": f"additive-rule-{field_name}-{index}-text"
+                    },
+                    rows="5",
+                    resize="vertical",
+                ),
+                rx.input(
+                    placeholder="Text",
+                    value=value.text,
+                    on_change=RuleState.set_text_value(field_name, index),
+                    style={
+                        "margin": "calc(-1 * var(--space-1))",
+                        "width": "100%",
+                    },
+                    custom_attrs={
+                        "data-testid": f"additive-rule-{field_name}-{index}-text"
+                    },
+                ),
             ),
         ),
         rx.cond(

--- a/mex/editor/rules/models.py
+++ b/mex/editor/rules/models.py
@@ -15,6 +15,7 @@ class InputConfig(rx.Base):
     editable_identifier: bool = False  # whether the identifier is editable as text
     editable_text: bool = False  # whether the text is editable as plain text
     allow_additive: bool = False  # whether this field belongs to an additive rule
+    render_textarea: bool = False  # whether this field is rendered as a textarea
 
 
 class ValidationMessage(rx.Base):

--- a/mex/editor/rules/transform.py
+++ b/mex/editor/rules/transform.py
@@ -1,5 +1,5 @@
 from functools import lru_cache
-from typing import cast
+from typing import Any, cast
 
 from pydantic import ValidationError
 
@@ -37,6 +37,7 @@ from mex.common.types import (
     TextLanguage,
 )
 from mex.editor.fields import (
+    ALL_MODEL_CLASSES_BY_NAME,
     REQUIRED_FIELDS_BY_CLASS_NAME,
     TEMPORAL_PRECISIONS_BY_FIELD_BY_CLASS_NAMES,
 )
@@ -118,6 +119,8 @@ def _transform_model_to_input_config(  # noqa: PLR0911
             allow_additive=editable,
         )
     if field_name in TEXT_FIELDS_BY_CLASS_NAME[entity_type]:
+        stem_type = cast("Any", ALL_MODEL_CLASSES_BY_NAME[entity_type]).stemType
+        model_config = MODEL_CONFIG_BY_STEM_TYPE[stem_type]
         return InputConfig(
             editable_text=editable,
             editable_badge=editable,
@@ -125,6 +128,7 @@ def _transform_model_to_input_config(  # noqa: PLR0911
             badge_options=[e.name for e in TextLanguage] + [LANGUAGE_VALUE_NONE],
             badge_titles=[TextLanguage.__name__],
             allow_additive=editable,
+            render_textarea=field_name in model_config.textarea,
         )
     if field_name in LINK_FIELDS_BY_CLASS_NAME[entity_type]:
         return InputConfig(

--- a/mex/editor/rules/transform.py
+++ b/mex/editor/rules/transform.py
@@ -1,5 +1,5 @@
 from functools import lru_cache
-from typing import Any, cast
+from typing import cast
 
 from pydantic import ValidationError
 
@@ -37,7 +37,6 @@ from mex.common.types import (
     TextLanguage,
 )
 from mex.editor.fields import (
-    ALL_MODEL_CLASSES_BY_NAME,
     REQUIRED_FIELDS_BY_CLASS_NAME,
     TEMPORAL_PRECISIONS_BY_FIELD_BY_CLASS_NAMES,
 )
@@ -96,6 +95,7 @@ def _transform_model_values_to_editor_values(
 def _transform_model_to_input_config(  # noqa: PLR0911
     field_name: str,
     entity_type: str,
+    stem_type: str,
     editable: bool,  # noqa: FBT001
 ) -> InputConfig:
     """Determine the input type for a given field of a given model."""
@@ -119,7 +119,6 @@ def _transform_model_to_input_config(  # noqa: PLR0911
             allow_additive=editable,
         )
     if field_name in TEXT_FIELDS_BY_CLASS_NAME[entity_type]:
-        stem_type = cast("Any", ALL_MODEL_CLASSES_BY_NAME[entity_type]).stemType
         model_config = MODEL_CONFIG_BY_STEM_TYPE[stem_type]
         return InputConfig(
             editable_text=editable,
@@ -201,6 +200,7 @@ def _transform_model_to_editor_primary_sources(
             input_config = _transform_model_to_input_config(
                 field_name,
                 model.entityType,
+                model.stemType,
                 editable=isinstance(model, AnyAdditiveModel),
             )
             primary_source = _create_editor_primary_source(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,6 +111,8 @@ def writer_user_page(
 ) -> Page:
     login_user(frontend_url, page, *writer_user_credentials)
     expect(page.get_by_test_id("nav-bar")).to_be_visible()
+    page.set_default_navigation_timeout(50000)
+    page.set_default_timeout(10000)
     return page
 
 

--- a/tests/edit/test_main.py
+++ b/tests/edit/test_main.py
@@ -24,6 +24,8 @@ def edit_page(
     load_dummy_data: None,  # noqa: ARG001
 ) -> Page:
     page = writer_user_page
+    page.set_default_navigation_timeout(50000)
+    page.set_default_timeout(10000)
     page.goto(f"{frontend_url}/item/{extracted_activity.stableTargetId}")
     page_body = page.get_by_test_id("page-body")
     expect(page_body).to_be_visible()

--- a/tests/edit/test_main.py
+++ b/tests/edit/test_main.py
@@ -305,6 +305,27 @@ def test_edit_page_renders_text_input(edit_page: Page) -> None:
 
 
 @pytest.mark.integration
+def test_edit_page_renders_textarea_input(edit_page: Page) -> None:
+    page = edit_page
+    new_additive_button = page.get_by_test_id(
+        "new-additive-alternativeTitle-00000000000000"
+    )
+    new_additive_button.scroll_into_view_if_needed()
+    expect(new_additive_button).to_be_visible()
+    new_additive_button.click()
+    page.screenshot(
+        path="tests_edit_test_main-test_edit_page_renders_textarea_input.png"
+    )
+
+    textarea_input = page.get_by_test_id("additive-rule-alternativeTitle-0-text")
+    expect(textarea_input).to_be_visible()
+    assert textarea_input.evaluate("el => el.tagName.toLowerCase()") == "textarea"
+
+    badge_select = page.get_by_test_id("additive-rule-alternativeTitle-0-badge")
+    expect(badge_select).to_be_visible()
+
+
+@pytest.mark.integration
 def test_edit_page_renders_identifier_input(edit_page: Page) -> None:
     page = edit_page
     new_additive_button = page.get_by_test_id(

--- a/tests/edit/test_main.py
+++ b/tests/edit/test_main.py
@@ -24,8 +24,6 @@ def edit_page(
     load_dummy_data: None,  # noqa: ARG001
 ) -> Page:
     page = writer_user_page
-    page.set_default_navigation_timeout(50000)
-    page.set_default_timeout(10000)
     page.goto(f"{frontend_url}/item/{extracted_activity.stableTargetId}")
     page_body = page.get_by_test_id("page-body")
     expect(page_body).to_be_visible()

--- a/tests/rules/test_transform.py
+++ b/tests/rules/test_transform.py
@@ -303,6 +303,20 @@ def test_transform_model_values_to_editor_values(
         ),
         pytest.param(
             "AdditiveResource",
+            "alternativeTitle",
+            InputConfig(
+                badge_options=["DE", "EN", LANGUAGE_VALUE_NONE],
+                badge_default="DE",
+                badge_titles=["TextLanguage"],
+                editable_badge=True,
+                editable_text=True,
+                allow_additive=True,
+                render_textarea=True,
+            ),
+            id="text area field",
+        ),
+        pytest.param(
+            "AdditiveResource",
             "minTypicalAge",
             InputConfig(
                 editable_text=True,
@@ -470,6 +484,7 @@ def test_transform_models_to_fields() -> None:
                     "editable_identifier": False,
                     "editable_text": False,
                     "allow_additive": False,
+                    "render_textarea": False,
                 },
                 "editor_values": [],
                 "enabled": True,
@@ -494,6 +509,7 @@ def test_transform_models_to_fields() -> None:
                     "editable_identifier": False,
                     "editable_text": True,
                     "allow_additive": True,
+                    "render_textarea": False,
                 },
                 "editor_values": [
                     {
@@ -534,6 +550,7 @@ def test_transform_models_to_fields() -> None:
                     "editable_identifier": False,
                     "editable_text": False,
                     "allow_additive": False,
+                    "render_textarea": False,
                 },
                 "editor_values": [],
                 "enabled": False,
@@ -558,6 +575,7 @@ def test_transform_models_to_fields() -> None:
                     "editable_identifier": True,
                     "editable_text": False,
                     "allow_additive": True,
+                    "render_textarea": False,
                 },
                 "editor_values": [],
                 "enabled": False,

--- a/tests/rules/test_transform.py
+++ b/tests/rules/test_transform.py
@@ -204,12 +204,14 @@ def test_transform_model_values_to_editor_values(
 @pytest.mark.parametrize(
     (
         "entity_type",
+        "stem_type",
         "field_name",
         "expected",
     ),
     [
         pytest.param(
             "AdditiveActivity",
+            "Activity",
             "fundingProgram",
             InputConfig(
                 editable_text=True,
@@ -219,6 +221,7 @@ def test_transform_model_values_to_editor_values(
         ),
         pytest.param(
             "AdditiveResource",
+            "Resource",
             "created",
             InputConfig(
                 badge_default="year",
@@ -240,6 +243,7 @@ def test_transform_model_values_to_editor_values(
         ),
         pytest.param(
             "AdditiveResource",
+            "Resource",
             "temporal",
             InputConfig(
                 editable_text=True,
@@ -249,12 +253,14 @@ def test_transform_model_values_to_editor_values(
         ),
         pytest.param(
             "AdditiveContactPoint",
+            "ContactPoint",
             "email",
             InputConfig(editable_text=True, allow_additive=True),
             id="email field",
         ),  # stopgap: MX-1766
         pytest.param(
             "AdditivePerson",
+            "Person",
             "affiliation",
             InputConfig(
                 editable_identifier=True,
@@ -264,6 +270,7 @@ def test_transform_model_values_to_editor_values(
         ),
         pytest.param(
             "AdditiveResource",
+            "Resource",
             "license",
             InputConfig(
                 badge_default="CREATIVE_COMMONS_ATTRIBUTION_INTERNATIONAL",
@@ -276,6 +283,7 @@ def test_transform_model_values_to_editor_values(
         ),
         pytest.param(
             "AdditiveResource",
+            "Resource",
             "documentation",
             InputConfig(
                 badge_options=["DE", "EN", LANGUAGE_VALUE_NONE],
@@ -290,6 +298,7 @@ def test_transform_model_values_to_editor_values(
         ),
         pytest.param(
             "AdditiveResource",
+            "Resource",
             "keyword",
             InputConfig(
                 badge_options=["DE", "EN", LANGUAGE_VALUE_NONE],
@@ -303,6 +312,7 @@ def test_transform_model_values_to_editor_values(
         ),
         pytest.param(
             "AdditiveResource",
+            "Resource",
             "alternativeTitle",
             InputConfig(
                 badge_options=["DE", "EN", LANGUAGE_VALUE_NONE],
@@ -317,6 +327,7 @@ def test_transform_model_values_to_editor_values(
         ),
         pytest.param(
             "AdditiveResource",
+            "Resource",
             "minTypicalAge",
             InputConfig(
                 editable_text=True,
@@ -324,15 +335,23 @@ def test_transform_model_values_to_editor_values(
             ),
             id="integer field",
         ),
-        pytest.param("AdditiveResource", "unknown", InputConfig(), id="unknown field"),
+        pytest.param(
+            "AdditiveResource", "Resource", "unknown", InputConfig(), id="unknown field"
+        ),
     ],
 )
 def test_transform_model_to_input_config(
     entity_type: str,
+    stem_type: str,
     field_name: str,
     expected: InputConfig,
 ) -> None:
-    input_config = _transform_model_to_input_config(field_name, entity_type, True)  # noqa: FBT003
+    input_config = _transform_model_to_input_config(
+        field_name,
+        entity_type,
+        stem_type,
+        True,  # noqa: FBT003
+    )
     assert input_config == expected
 
 
@@ -689,60 +708,69 @@ def test_transform_fields_to_preventive(
 
 
 @pytest.mark.parametrize(
-    ("editor_value", "field_name", "class_name", "expected"),
+    ("editor_value", "field_name", "class_name", "stem_type", "expected"),
     [
         (
             EditorValue(text="Titel", badge="DE", href="https://beispiel"),
             "documentation",
             "AdditiveResource",
+            "Resource",
             Link(url="https://beispiel", language=LinkLanguage.DE, title="Titel"),
         ),
         (
             EditorValue(text="Beispiel Text", badge="DE"),
             "alternativeName",
             "AdditiveOrganization",
+            "Organization",
             Text(language=TextLanguage.DE, value="Beispiel Text"),
         ),
         (
             EditorValue(text="Text", badge=LANGUAGE_VALUE_NONE),
             "alternativeTitle",
             "AdditivePrimarySource",
+            "PrimarySource",
             Text(language=None, value="Text"),
         ),
         (
             EditorValue(text="ConsentStatus", badge="EXPRESSED_CONSENT"),
             "hasConsentType",
             "AdditiveConsent",
+            "Consent",
             ConsentType["EXPRESSED_CONSENT"],
         ),
         (
             EditorValue(),
             "accrualPeriodicity",
             "AdditiveResource",
+            "Resource",
             Frequency["TRIENNIAL"],
         ),
         (
             EditorValue(text="2004", badge="year"),
             "start",
             "AdditiveActivity",
+            "Activity",
             Year(2004),
         ),
         (
             EditorValue(text="Funds for Funding e.V."),
             "fundingProgram",
             "AdditiveActivity",
+            "Activity",
             "Funds for Funding e.V.",
         ),
         (
             EditorValue(identifier="abcdefhijkglmno"),
             "hadPrimarySource",
             "ExtractedActivity",
+            "Activity",
             "abcdefhijkglmno",
         ),
         (
             EditorValue(identifier="abcdefhijkglmno", text="foo"),
             "hadPrimarySource",
             "ExtractedActivity",
+            "Activity",
             "abcdefhijkglmno",
         ),
     ],
@@ -759,9 +787,18 @@ def test_transform_fields_to_preventive(
     ],
 )
 def test_transform_editor_value_to_model_value(
-    editor_value: EditorValue, field_name: str, class_name: str, expected: object
+    editor_value: EditorValue,
+    field_name: str,
+    class_name: str,
+    stem_type: str,
+    expected: object,
 ) -> None:
-    input_config = _transform_model_to_input_config(field_name, class_name, True)  # noqa: FBT003
+    input_config = _transform_model_to_input_config(
+        field_name,
+        class_name,
+        stem_type,
+        True,  # noqa: FBT003
+    )
     assert input_config
 
     model_value = _transform_editor_value_to_model_value(


### PR DESCRIPTION
### PR Context
<!-- Additional info for the reviewer -->

### Added
<!-- New features and interfaces -->
- added textareas for fields listed in mex/editor/models.yaml

### Changes
<!-- Changes in existing functionality -->

### Deprecated
<!-- Soon-to-be removed features -->

### Removed
<!-- Definitely removed features -->

### Fixed
<!-- Fixed bugs -->

### Security
<!-- Fixed vulnerabilities -->
