### PR TITLE
hotfix/mx-2042 incorrect default language for link and text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- fix badge default for link and text
 - fix title of edit page to be equal to search snippet
 
 ### Security

--- a/mex/editor/rules/transform.py
+++ b/mex/editor/rules/transform.py
@@ -123,7 +123,7 @@ def _transform_model_to_input_config(  # noqa: PLR0911
         return InputConfig(
             editable_text=editable,
             editable_badge=editable,
-            badge_default=TextLanguage.DE.name,
+            badge_default=LANGUAGE_VALUE_NONE,
             badge_options=[e.name for e in TextLanguage] + [LANGUAGE_VALUE_NONE],
             badge_titles=[TextLanguage.__name__],
             allow_additive=editable,
@@ -134,7 +134,7 @@ def _transform_model_to_input_config(  # noqa: PLR0911
             editable_text=editable,
             editable_badge=editable,
             editable_href=editable,
-            badge_default=LinkLanguage.DE.name,
+            badge_default=LANGUAGE_VALUE_NONE,
             badge_options=[e.name for e in LinkLanguage] + [LANGUAGE_VALUE_NONE],
             badge_titles=[LinkLanguage.__name__],
             allow_additive=editable,

--- a/tests/rules/test_transform.py
+++ b/tests/rules/test_transform.py
@@ -287,7 +287,7 @@ def test_transform_model_values_to_editor_values(
             "documentation",
             InputConfig(
                 badge_options=["DE", "EN", LANGUAGE_VALUE_NONE],
-                badge_default="DE",
+                badge_default=LANGUAGE_VALUE_NONE,
                 badge_titles=["LinkLanguage"],
                 editable_href=True,
                 editable_badge=True,
@@ -302,7 +302,7 @@ def test_transform_model_values_to_editor_values(
             "keyword",
             InputConfig(
                 badge_options=["DE", "EN", LANGUAGE_VALUE_NONE],
-                badge_default="DE",
+                badge_default=LANGUAGE_VALUE_NONE,
                 badge_titles=["TextLanguage"],
                 editable_badge=True,
                 editable_text=True,
@@ -316,7 +316,7 @@ def test_transform_model_values_to_editor_values(
             "alternativeTitle",
             InputConfig(
                 badge_options=["DE", "EN", LANGUAGE_VALUE_NONE],
-                badge_default="DE",
+                badge_default=LANGUAGE_VALUE_NONE,
                 badge_titles=["TextLanguage"],
                 editable_badge=True,
                 editable_text=True,


### PR DESCRIPTION
### PR Context
Found a bug while editing MX-1990. Simply changed the defualt badge value to none which was used by default even when de was set as default.

### Added
<!-- New features and interfaces -->

### Changes
<!-- Changes in existing functionality -->

### Deprecated
<!-- Soon-to-be removed features -->

### Removed
<!-- Definitely removed features -->

### Fixed
- badge default for link and text

### Security
<!-- Fixed vulnerabilities -->
