### PR TITLE
feature/mx-2021 translate reference filter field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- CustomSelect-Component that has items with value and label instead of simple strings
 
 ### Changes
+- Field of the ReferenceFilter is now translated
 
 ### Deprecated
 

--- a/mex/editor/search/custom_select.py
+++ b/mex/editor/search/custom_select.py
@@ -1,0 +1,98 @@
+from typing import Any
+
+import reflex as rx
+from reflex.components import Component
+from reflex.components.radix.themes.components.select import (
+    HighLevelSelect,
+    SelectContent,
+    SelectGroup,
+    SelectItem,
+    SelectLabel,
+    SelectRoot,
+    SelectTrigger,
+)
+from reflex.vars.base import Var
+
+
+class CustomHighLevelSelect(HighLevelSelect):
+    """High level wrapper for the Select component."""
+
+    @classmethod
+    def create_value_label_select(
+        cls,
+        items: list[dict[str, str]] | Var[list[dict[str, str]]],
+        **props,  # noqa: ANN003
+    ) -> Component:
+        """Create a select component. THIS IS COPY PASTE FROM HighLevelSelect!
+
+        Args:
+            items: The items (as dict with "label" and "value") of the select.
+            **props: Additional properties to apply to the select component.
+
+        Returns:
+            The select component.
+        """
+        trigger_prop_list = [
+            "id",
+            "placeholder",
+            "variant",
+            "radius",
+            "width",
+            "flex_shrink",
+            "custom_attrs",
+        ]
+
+        content_props = {
+            prop: props.pop(prop)
+            for prop in ["high_contrast", "position"]
+            if prop in props
+        }
+
+        trigger_props = {
+            prop: props.pop(prop) for prop in trigger_prop_list if prop in props
+        }
+
+        color_scheme = props.pop("color_scheme", None)
+
+        if color_scheme is not None:
+            content_props["color_scheme"] = color_scheme
+            trigger_props["color_scheme"] = color_scheme
+
+        label = props.pop("label", None)
+
+        child: list[Any] = []
+        if isinstance(items, Var):
+            child = [
+                rx.foreach(
+                    items,
+                    lambda item: SelectItem.create(
+                        item["label"],
+                        value=item["value"],
+                    ),
+                )
+            ]
+        else:
+            child = [
+                SelectItem.create(
+                    item["label"],
+                    value=item["value"],
+                )
+                for item in items
+            ]
+
+        return SelectRoot.create(
+            SelectTrigger.create(
+                **trigger_props,
+            ),
+            SelectContent.create(
+                SelectGroup.create(
+                    SelectLabel.create(label) if label is not None else "",
+                    *child,
+                ),
+                **content_props,
+            ),
+            **props,
+        )
+
+
+custom_select = CustomHighLevelSelect.create_value_label_select

--- a/mex/editor/search/main.py
+++ b/mex/editor/search/main.py
@@ -9,13 +9,13 @@ from mex.editor.components import (
     render_title,
 )
 from mex.editor.layout import page
-from mex.editor.search.custom_select import custom_select
 from mex.editor.search.models import (
     ReferenceFieldIdentifierFilter,
     SearchPrimarySource,
     SearchResult,
 )
 from mex.editor.search.state import SearchState, full_refresh
+from mex.editor.search.value_label_select import value_label_select
 
 
 def search_result(result: SearchResult) -> rx.Component:
@@ -188,7 +188,7 @@ def reference_field_filter() -> rx.Component:
     """Render dropdown and text inputs for reference filtering the search result."""
     return rx.vstack(
         rx.hstack(
-            custom_select(
+            value_label_select(
                 items=SearchState.all_fields_for_entity_types,
                 value=SearchState.reference_field_filter.field,
                 placeholder="Field to filter by",

--- a/mex/editor/search/main.py
+++ b/mex/editor/search/main.py
@@ -9,6 +9,7 @@ from mex.editor.components import (
     render_title,
 )
 from mex.editor.layout import page
+from mex.editor.search.custom_select import custom_select
 from mex.editor.search.models import (
     ReferenceFieldIdentifierFilter,
     SearchPrimarySource,
@@ -187,7 +188,7 @@ def reference_field_filter() -> rx.Component:
     """Render dropdown and text inputs for reference filtering the search result."""
     return rx.vstack(
         rx.hstack(
-            rx.select(
+            custom_select(
                 items=SearchState.all_fields_for_entity_types,
                 value=SearchState.reference_field_filter.field,
                 placeholder="Field to filter by",

--- a/mex/editor/search/state.py
+++ b/mex/editor/search/state.py
@@ -14,6 +14,7 @@ from mex.common.models import MERGED_MODEL_CLASSES, MergedPrimarySource
 from mex.common.transform import ensure_prefix
 from mex.common.types import Identifier
 from mex.editor.exceptions import escalate_error
+from mex.editor.locale_service import LocaleService
 from mex.editor.search.models import (
     ReferenceFieldFilter,
     ReferenceFieldIdentifierFilter,
@@ -52,6 +53,9 @@ def _build_had_primary_source_refresh_params(
         "reference_field": "hadPrimarySource" if had_primary_source else None,
         "referenced_identifier": had_primary_source,
     }
+
+
+locale_service = LocaleService.get()
 
 
 class SearchState(State):
@@ -128,7 +132,7 @@ class SearchState(State):
         )
 
     @rx.var(cache=False)
-    def all_fields_for_entity_types(self) -> list[str]:
+    def all_fields_for_entity_types(self) -> list[dict[str, str]]:
         """Get all fields for the currently selected entity types filter.
 
         Returns:
@@ -142,11 +146,28 @@ class SearchState(State):
         if len(selected_entity_types) == 0:
             selected_entity_types = [item[0] for item in self.entity_types.items()]
 
-        fields_by_type = [
-            REFERENCE_FIELDS_BY_CLASS_NAME[ensure_prefix(entity_type, "Extracted")]
+        fields_with_type = [
+            [
+                {
+                    "value": field,
+                    "label": locale_service.get_field_label(
+                        self.current_locale, entity_type, field
+                    ),
+                }
+                for field in REFERENCE_FIELDS_BY_CLASS_NAME[
+                    ensure_prefix(entity_type, "Extracted")
+                ]
+            ]
             for entity_type in selected_entity_types
         ]
-        return sorted({f for fields in fields_by_type for f in fields})
+
+        return sorted(
+            {
+                item["value"]: item
+                for item in [f for fields in fields_with_type for f in fields]
+            }.values(),
+            key=lambda x: x["label"],
+        )
 
     @rx.var(cache=False)
     def disable_previous_page(self) -> bool:

--- a/mex/editor/search/state.py
+++ b/mex/editor/search/state.py
@@ -22,6 +22,7 @@ from mex.editor.search.models import (
     SearchResult,
 )
 from mex.editor.search.transform import transform_models_to_results
+from mex.editor.search.value_label_select import ValueLabelSelectItem
 from mex.editor.state import State
 from mex.editor.utils import resolve_editor_value
 
@@ -55,9 +56,6 @@ def _build_had_primary_source_refresh_params(
     }
 
 
-locale_service = LocaleService.get()
-
-
 class SearchState(State):
     """State management for the search page."""
 
@@ -74,6 +72,7 @@ class SearchState(State):
         field="", identifiers=[]
     )
     is_loading: bool = True
+    _locale_service = LocaleService.get()
 
     @rx.event
     def set_reference_filter_field(self, value: str) -> None:
@@ -132,7 +131,7 @@ class SearchState(State):
         )
 
     @rx.var(cache=False)
-    def all_fields_for_entity_types(self) -> list[dict[str, str]]:
+    def all_fields_for_entity_types(self) -> list[ValueLabelSelectItem]:
         """Get all fields for the currently selected entity types filter.
 
         Returns:
@@ -148,12 +147,12 @@ class SearchState(State):
 
         fields_with_type = [
             [
-                {
-                    "value": field,
-                    "label": locale_service.get_field_label(
+                ValueLabelSelectItem(
+                    value=field,
+                    label=self._locale_service.get_field_label(
                         self.current_locale, entity_type, field
                     ),
-                }
+                )
                 for field in REFERENCE_FIELDS_BY_CLASS_NAME[
                     ensure_prefix(entity_type, "Extracted")
                 ]
@@ -163,10 +162,10 @@ class SearchState(State):
 
         return sorted(
             {
-                item["value"]: item
+                item.value: item
                 for item in [f for fields in fields_with_type for f in fields]
             }.values(),
-            key=lambda x: x["label"],
+            key=lambda x: x.label,
         )
 
     @rx.var(cache=False)

--- a/mex/editor/search/value_label_select.py
+++ b/mex/editor/search/value_label_select.py
@@ -1,6 +1,8 @@
+from collections.abc import Sequence
 from typing import Any
 
 import reflex as rx
+from reflex.base import BaseModel
 from reflex.components import Component
 from reflex.components.radix.themes.components.select import (
     HighLevelSelect,
@@ -14,19 +16,26 @@ from reflex.components.radix.themes.components.select import (
 from reflex.vars.base import Var
 
 
-class CustomHighLevelSelect(HighLevelSelect):
+class ValueLabelSelectItem(BaseModel):
+    """Items for ValueLabelHighLevelSelect that contain value and label."""
+
+    value: str
+    label: str
+
+
+class ValueLabelHighLevelSelect(HighLevelSelect):
     """High level wrapper for the Select component."""
 
     @classmethod
     def create_value_label_select(
         cls,
-        items: list[dict[str, str]] | Var[list[dict[str, str]]],
+        items: Sequence[ValueLabelSelectItem] | Var[Sequence[ValueLabelSelectItem]],
         **props,  # noqa: ANN003
     ) -> Component:
         """Create a select component. THIS IS COPY PASTE FROM HighLevelSelect!
 
         Args:
-            items: The items (as dict with "label" and "value") of the select.
+            items: The items (with "label" and "value") of the select.
             **props: Additional properties to apply to the select component.
 
         Returns:
@@ -66,16 +75,16 @@ class CustomHighLevelSelect(HighLevelSelect):
                 rx.foreach(
                     items,
                     lambda item: SelectItem.create(
-                        item["label"],
-                        value=item["value"],
+                        item.label,
+                        value=item.value,
                     ),
                 )
             ]
         else:
             child = [
                 SelectItem.create(
-                    item["label"],
-                    value=item["value"],
+                    item.label,
+                    value=item.value,
                 )
                 for item in items
             ]
@@ -95,4 +104,4 @@ class CustomHighLevelSelect(HighLevelSelect):
         )
 
 
-custom_select = CustomHighLevelSelect.create_value_label_select
+value_label_select = ValueLabelHighLevelSelect.create_value_label_select

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,7 +128,7 @@ def writer_user_page(
     login_user(frontend_url, page, *writer_user_credentials)
     expect(page.get_by_test_id("nav-bar")).to_be_visible()
     page.set_default_navigation_timeout(50000)
-    page.set_default_timeout(10000)
+    page.set_default_timeout(20000)
     return page
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,17 +50,6 @@ def browser_context_args(
     }
 
 
-@pytest.fixture(scope="session")
-def browser_type_launch_args(
-    browser_type_launch_args: dict[str, Any],
-) -> dict[str, Any]:
-    """Run the playwright browser always in headless mode."""
-    return {
-        **browser_type_launch_args,
-        "headless": True,
-    }
-
-
 @pytest.fixture
 def client() -> TestClient:
     """Return a fastAPI test client initialized with our app."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,8 +128,8 @@ def writer_user_page(
     login_user(frontend_url, page, *writer_user_credentials)
     expect(page.get_by_test_id("nav-bar")).to_be_visible()
     page.set_default_navigation_timeout(50_000)
-    page.set_default_timeout(10_000)
-    expect.set_options(timeout=10_000)
+    page.set_default_timeout(15_000)
+    expect.set_options(timeout=15_000)
     return page
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-import os
 from typing import Any
 
 import pytest
@@ -55,10 +54,10 @@ def browser_context_args(
 def browser_type_launch_args(
     browser_type_launch_args: dict[str, Any],
 ) -> dict[str, Any]:
-    """Run the playwright browser in headed mode locally and in headless mode in CI."""
+    """Run the playwright browser always in headless mode."""
     return {
         **browser_type_launch_args,
-        "headless": os.getenv("CI") is not None,
+        "headless": True,
     }
 
 

--- a/tests/search/test_main.py
+++ b/tests/search/test_main.py
@@ -228,14 +228,62 @@ def test_reference_filter_fields_for_entity_type(
     )
 
     expected_person_fields = [
-        "memberOf",
-        "affiliation",
-        "hadPrimarySource",
-        "stableTargetId",
+        "Fachgebiet",
+        "Affiliation",
+        "Primärsystem",
+        "Stabiler Identifikator",
     ]
     for field in expected_person_fields:
-        select_item = page.get_by_role("option", name=field)
+        select_item = page.get_by_role("option", name=field, exact=True)
         expect(select_item).to_be_visible()
+
+
+@pytest.mark.parametrize(
+    ("locale_id", "expected_items"),
+    [
+        pytest.param(
+            "de-DE",
+            [
+                "Affiliation",
+                "Autor*in",
+                "Datei",
+                "Fachgebiet",
+                "Kontakt",
+                "Nachfolge von",
+            ],
+            id="de-DE",
+        ),
+        pytest.param(
+            "en-US",
+            [
+                "Affiliation",
+                "Access platform",
+                "Contact",
+                "Author",
+                "Files",
+                "Publisher",
+            ],
+            id="en-US",
+        ),
+    ],
+)
+@pytest.mark.integration
+def test_reference_filter_field_translation(
+    frontend_url: str, writer_user_page: Page, locale_id: str, expected_items: list[str]
+) -> None:
+    page = writer_user_page
+    page.goto(frontend_url)
+    page.wait_for_selector("[data-testid='page-body']")
+
+    # switch language to specifid locale
+    lang_switcher = page.get_by_test_id("language-switcher")
+    lang_switcher.click()
+    page.get_by_test_id(f"language-switcher-menu-item-{locale_id}").click()
+
+    # check expected items existing
+    page.get_by_test_id("reference-field-filter-field").click()
+    for item in expected_items:
+        expect(page.get_by_role("option", name=item, exact=True)).to_be_visible()
 
 
 @pytest.mark.integration
@@ -253,7 +301,7 @@ def test_reference_filter(
     # open select
     page.get_by_test_id("reference-field-filter-field").click()
     # click concat option
-    page.get_by_role("option", name="contact").click()
+    page.get_by_role("option", name="Kontakt").click()
     # add invalid field
     page.get_by_test_id("reference-field-filter-add-id").click()
     page.get_by_test_id("reference-field-filter-id-0").fill("invalidIdentifier!")


### PR DESCRIPTION
### PR Context
Not all fields are translated and diffferent field names translate to the same word/phrase. I created a ticket (mx-2070) for this.

### Added
- CustomSelect-Component that has items with value and label instead of simple strings

### Changes
- Field of the ReferenceFilter is now translated

### Deprecated
<!-- Soon-to-be removed features -->

### Removed
<!-- Definitely removed features -->

### Fixed
<!-- Fixed bugs -->

### Security
<!-- Fixed vulnerabilities -->
