### PR TITLE
Bump cookiecutter template to 3c389d

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "a287d7c8a604fa376f3986b0dbcb53d6354c68fe",
+  "commit": "3c389d7e70f3d3146de3a31c7f94a901184f45b8",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -8,7 +8,7 @@
       "short_summary": "Metadata editor web application.",
       "long_summary": "The `mex-editor` is a browser application that allows creating and editing rules to non-destructively manipulate metadata. This can be used to enrich data with manual input or insert new data from scratch.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "a287d7c8a604fa376f3986b0dbcb53d6354c68fe"
+      "_commit": "3c389d7e70f3d3146de3a31c7f94a901184f45b8"
     }
   },
   "directory": null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changes
+- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/3c389d
 - Increased global expect timeout (to 10,000) for tests
 - Using the field label for new/remove additive value button
 - renaming the field_name function to field_name_card

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ cruft==2.16.0
 mex-release==0.3.5
 pdm==2.26.0
 pre-commit==4.3.0
+hishel<1


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/3c389d
