### PR TITLE
Bump cookiecutter template to 6009e2

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "3c389d7e70f3d3146de3a31c7f94a901184f45b8",
+  "commit": "6009e248d0af40a236c73776716f077c9a9cc313",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -8,7 +8,7 @@
       "short_summary": "Metadata editor web application.",
       "long_summary": "The `mex-editor` is a browser application that allows creating and editing rules to non-destructively manipulate metadata. This can be used to enrich data with manual input or insert new data from scratch.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "3c389d7e70f3d3146de3a31c7f94a901184f45b8"
+      "_commit": "6009e248d0af40a236c73776716f077c9a9cc313"
     }
   },
   "directory": null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changes
+- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/6009e2
 
 - Initial language now picking from available languages instead of hard coded value
 - bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/3c389d

--- a/tests/create/test_main.py
+++ b/tests/create/test_main.py
@@ -118,7 +118,7 @@ def test_language_switcher(
     create_page.get_by_test_id(f"language-switcher-menu-item-{locale_id}").click()
 
     # select entity_type resource
-    create_page.get_by_test_id("entity-type-select").click(timeout=20000)
+    create_page.get_by_test_id("entity-type-select").click(timeout=30_000)
     create_page.get_by_role("option", name="Resource", exact=True).click()
     create_page.wait_for_timeout(20000)
 

--- a/tests/ingest/test_main.py
+++ b/tests/ingest/test_main.py
@@ -66,7 +66,7 @@ def test_search_and_ingest_roundtrip(
 
     # go to the correct tab
     aux_provider_tab = page.get_by_role("tab", name=aux_provider)
-    expect(aux_provider_tab).to_be_enabled(timeout=30000)
+    expect(aux_provider_tab).to_be_enabled(timeout=30_000)
     aux_provider_tab.click()
     search_input = page.get_by_placeholder("Search here...")
     expect(search_input).to_be_visible()
@@ -75,7 +75,7 @@ def test_search_and_ingest_roundtrip(
     # trigger invalid search
     search_input.fill(invalid_search)
     search_input.press("Enter")
-    expect(search_input).to_be_enabled(timeout=30000)
+    expect(search_input).to_be_enabled(timeout=30_000)
     page.screenshot(
         path=f"tests_ingest_test_main-roundtrip_{aux_provider}-invalid-search.png"
     )
@@ -88,14 +88,14 @@ def test_search_and_ingest_roundtrip(
     # trigger valid search
     search_input.fill(valid_search)
     search_input.press("Enter")
-    expect(search_input).to_be_enabled(timeout=30000)
+    expect(search_input).to_be_enabled(timeout=30_000)
     page.screenshot(
         path=f"tests_ingest_test_main-roundtrip_{aux_provider}-valid-search.png"
     )
 
     # test pagination is showing
     prev_button = page.get_by_test_id("pagination-previous-button")
-    expect(prev_button).to_be_disabled(timeout=30000)
+    expect(prev_button).to_be_disabled(timeout=30_000)
     expect(page.get_by_test_id("pagination-next-button")).to_be_visible()
     expect(page.get_by_test_id("pagination-page-select")).to_be_visible()
 
@@ -150,7 +150,7 @@ def test_infobox_visibility_and_content(ingest_page: Page) -> None:
     for provider in ALL_AUX_PROVIDERS:
         tab = page.get_by_role("tab", name=provider)
         tab.click(
-            timeout=50000
+            timeout=30_000
         )  # high timeout cuz tab might be disabled due to loading
 
         tab_content = page.locator(f"[id*='{provider}'][role='tabpanel']")

--- a/tests/search/test_main.py
+++ b/tests/search/test_main.py
@@ -363,7 +363,7 @@ def test_push_search_params(
 
     # load page and verify url
     page.goto(frontend_url)
-    page.wait_for_url("**/", timeout=10000)
+    page.wait_for_url("**/")
 
     # select an entity type
     entity_types = page.get_by_test_id("entity-types")

--- a/tests/search/test_main.py
+++ b/tests/search/test_main.py
@@ -398,10 +398,10 @@ def test_push_search_params(
     page.screenshot(path="tests_search_test_main-test_push_search_params-on-load-2.png")
     primary_sources.get_by_text(primary_source.title[0].value).click()
     checked = primary_sources.get_by_role("checkbox", checked=True)
+    expect(checked).to_have_count(1)
     page.screenshot(
         path="tests_search_test_main-test_push_search_params-on-click-2.png"
     )
-    expect(checked).to_have_count(1)
 
     # expect parameter change to be reflected in url
     page.wait_for_url(


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/6009e2
