### PR TITLE
Bump cookiecutter template to a67c71

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "6009e248d0af40a236c73776716f077c9a9cc313",
+  "commit": "a67c7163c76384de4f85913f0f6045a41dcd0735",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -8,7 +8,7 @@
       "short_summary": "Metadata editor web application.",
       "long_summary": "The `mex-editor` is a browser application that allows creating and editing rules to non-destructively manipulate metadata. This can be used to enrich data with manual input or insert new data from scratch.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "6009e248d0af40a236c73776716f077c9a9cc313"
+      "_commit": "a67c7163c76384de4f85913f0f6045a41dcd0735"
     }
   },
   "directory": null

--- a/.github/workflows/changelog-checking.yml
+++ b/.github/workflows/changelog-checking.yml
@@ -1,0 +1,35 @@
+name: Check changelog
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-changelog:
+    name: Check changelog
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Check for CHANGELOG.md changes
+        run: |
+          if [ "${{ github.actor }}" = "RKIMetadataExchange" ]; then
+            echo "Actor is 'RKIMetadataExchange'. Skipping changelog check."
+            exit 0;
+          fi
+
+          if git diff --quiet "origin/${{ github.base_ref }}"...HEAD -- "CHANGELOG.md"; then
+            echo "Error: The CHANGELOG.md has not been modified."
+            echo "Please add your changes to CHANGELOG.md before merging."
+            exit 1
+          else
+            echo "CHANGELOG.md has been modified."
+            exit 0
+          fi

--- a/.github/workflows/cookiecutter.yml
+++ b/.github/workflows/cookiecutter.yml
@@ -76,7 +76,7 @@ jobs:
           git checkout -b cruft/cookiecutter-template-${template_ref}
           cruft update --skip-apply-ask
           printf '# Changes\n\n- bumped cookiecutter template to %s/commit/%s\n' "$template_url" "$template_ref" > .cruft-pr-body
-          sed -i "0,/^### Changes/s|^### Changes.*|&\n- bumped cookiecutter template to ${template_url}/commit/${template_ref}|" CHANGELOG.md
+          sed -i "0,/^### Changes/s|^### Changes.*|&\n\n- updated template to ${template_url}/commit/${template_ref}|" CHANGELOG.md
           if [[ $(find . -type f -name "*.rej" | wc -l) -ne 0 ]]; then
             printf '\n# Conflicts\n' >> .cruft-pr-body
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     outputs:
       tag: ${{ steps.release.outputs.tag }}
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
   python: python3.11
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.13.3
+    rev: v0.14.5
     hooks:
       - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
       - id: fix-byte-order-marker
         name: byte-order
   - repo: https://github.com/pdm-project/pdm
-    rev: 2.25.9
+    rev: 2.26.1
     hooks:
       - id: pdm-lock-check
         name: pdm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CustomSelect-Component that has items with value and label instead of simple strings
 
 ### Changes
+- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/a67c71
 
 - bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/6009e2
 - Field of the ReferenceFilter is now translated

--- a/docs/layout.html
+++ b/docs/layout.html
@@ -11,7 +11,7 @@
         <a href="https://docs.github.com/site-policy/privacy-policies/github-privacy-statement" rel="nofollow">
             GitHub Privacy
         </a> |
-        <a href="https://docs.github.com/en/site-policy/privacy-policies/github-cookies" rel="nofollow">
+        <a href="https://docs.github.com/site-policy/privacy-policies/github-cookies" rel="nofollow">
             GitHub Cookies
         </a>
     </div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ cruft==2.16.0
 mex-release==0.3.5
 pdm==2.26.1
 pre-commit==4.4.0
-hishel<1


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/a67c71
