### PR TITLE
Bump cookiecutter template to 7c3e75

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "a67c7163c76384de4f85913f0f6045a41dcd0735",
+  "commit": "7c3e752b1fa728e1b003be1bdf5190b19bbc1db6",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -8,7 +8,7 @@
       "short_summary": "Metadata editor web application.",
       "long_summary": "The `mex-editor` is a browser application that allows creating and editing rules to non-destructively manipulate metadata. This can be used to enrich data with manual input or insert new data from scratch.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "a67c7163c76384de4f85913f0f6045a41dcd0735"
+      "_commit": "7c3e752b1fa728e1b003be1bdf5190b19bbc1db6"
     }
   },
   "directory": null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- updated template to https://github.com/robert-koch-institut/mex-template/commit/7c3e75
+
 ### Deprecated
 
 ### Removed

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cruft==2.16.0
 mex-release==0.3.5
-pdm==2.26.2
+pdm<2.26.2
 pre-commit==4.5.0


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/7c3e75
