### PR TITLE
Bump cookiecutter template to c5ff3e

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "7c3e752b1fa728e1b003be1bdf5190b19bbc1db6",
+  "commit": "c5ff3ea8c021bb5bf85b1893de303f522a016956",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -8,7 +8,7 @@
       "short_summary": "Metadata editor web application.",
       "long_summary": "The `mex-editor` is a browser application that allows creating and editing rules to non-destructively manipulate metadata. This can be used to enrich data with manual input or insert new data from scratch.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "7c3e752b1fa728e1b003be1bdf5190b19bbc1db6"
+      "_commit": "c5ff3ea8c021bb5bf85b1893de303f522a016956"
     }
   },
   "directory": null

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,12 +68,12 @@ jobs:
           SIGNING_PUB: ${{ secrets.SIGNING_PUB }}
         run: |
           eval "$(ssh-agent -s)"
-          pdm setup-commit-signing
+          mex setup-commit-signing
 
       - name: Release new version
         id: release
         run: |
-          pdm release ${{ inputs.version }}
+          mex release ${{ inputs.version }}
           echo "tag=$(git describe --abbrev=0 --tags)" >> "$GITHUB_OUTPUT"
 
   containerize:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- updated template to https://github.com/robert-koch-institut/mex-template/commit/c5ff3e
+
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/7c3e75
 - Using href navigation instead of navigation via code (`page.navigate()`).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,5 +159,11 @@ known-first-party = ["mex", "tests"]
 convention = "google"
 
 [build-system]
-requires = ["pdm-backend==2.4.6"]
-build-backend = "pdm.backend"
+requires = ["hatchling>=1.28.0"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["mex"]
+
+[tool.hatch.build.targets.sdist]
+packages = ["mex"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cruft==2.16.0
-mex-release==0.3.5
+mex-release==1.0.0
 pdm<2.26.2
 pre-commit==4.5.0


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/c5ff3e
