### PR TITLE
feature/mx-2109 setup cve scanning for package lock json

### DIFF
--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -67,7 +67,7 @@ jobs:
           python-version: 3.11
 
       - name: Install requirements
-        run: make setup
+        run: make install
 
       - name: Export dependencies
         run: |

--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -21,6 +21,20 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+
+    services:
+      backend:
+        image: ghcr.io/robert-koch-institut/mex-backend:1.2.0
+        env:
+          MEX_BACKEND_API_USER_DATABASE: ${{ secrets.MEX_BACKEND_API_USER_DATABASE }}
+          MEX_BACKEND_API_KEY_DATABASE: ${{ secrets.MEX_BACKEND_API_KEY_DATABASE }}
+          MEX_IDENTITY_PROVIDER: graph
+          MEX_GRAPH_URL: neo4j://neo4j:7687
+          MEX_DEBUG: True
+        ports:
+          - 8080:8080
+        options: --entrypoint testing-backend
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
@@ -60,15 +74,9 @@ jobs:
           mkdir --parents pdm
           pdm export --group :all --no-hashes -f requirements > pdm/requirements.txt
 
-      - name: Install dependencies (for Reflex)
+      - name: Generate package-lock.json
         run: |
-          pip install -r pdm/requirements.txt
-          pip install --no-deps -e .
-
-      - name: Prepare Frontend (Reflex)
-        run: |
-          reflex export --frontend-only --no-zip
-
+          pdm run reflex export --frontend-only --no-zip
           cd .web
           npm install --package-lock-only --legacy-peer-deps
 

--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -22,19 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
-    services:
-      backend:
-        image: ghcr.io/robert-koch-institut/mex-backend:1.2.0
-        env:
-          MEX_BACKEND_API_USER_DATABASE: ${{ secrets.MEX_BACKEND_API_USER_DATABASE }}
-          MEX_BACKEND_API_KEY_DATABASE: ${{ secrets.MEX_BACKEND_API_KEY_DATABASE }}
-          MEX_IDENTITY_PROVIDER: graph
-          MEX_GRAPH_URL: neo4j://neo4j:7687
-          MEX_DEBUG: True
-        ports:
-          - 8080:8080
-        options: --entrypoint testing-backend
-
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6

--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -60,6 +60,18 @@ jobs:
           mkdir --parents pdm
           pdm export --group :all --no-hashes -f requirements > pdm/requirements.txt
 
+      - name: Install dependencies (for Reflex)
+        run: |
+          pip install -r pdm/requirements.txt
+          pip install --no-deps -e .
+
+      - name: Prepare Frontend (Reflex)
+        run: |
+          reflex export --frontend-only --no-zip
+
+          cd .web
+          npm install --package-lock-only --legacy-peer-deps
+
       - name: Run trivy
         uses: aquasecurity/trivy-action@master
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - LocalStorage to store drafts and edits local on browser side.
+- add cve scanning of frontend dependencies
 
 ### Changes
 

--- a/mex/editor/state.py
+++ b/mex/editor/state.py
@@ -153,7 +153,7 @@ class State(rx.State):
         """Return the version of mex-editor."""
         return version("mex-editor")
 
-    @rx.var(cache=True)
+    @rx.var(cache=True, initial_value="N/A")
     def backend_version(self) -> str:
         """Return the version of mex-backend."""
         connector = BackendApiConnector.get()


### PR DESCRIPTION
### PR Context

refer to https://github.com/robert-koch-institut/mex-drop/pull/389

additionally, we need to spin up a backend container because for some reason reflex tries to connect to it even when just running `reflex export`

### Added
- add cve scanning of frontend dependencies
