### PR TITLE
Bump cookiecutter template to b87502

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "20393408cdeb5166dd14cd0782237b002138a363",
+  "commit": "b87502b8dc3a10172e44c390cf7753b8b1fc9b8a",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -8,7 +8,7 @@
       "short_summary": "Metadata editor web application.",
       "long_summary": "The `mex-editor` is a browser application that allows creating and editing rules to non-destructively manipulate metadata. This can be used to enrich data with manual input or insert new data from scratch.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "20393408cdeb5166dd14cd0782237b002138a363"
+      "_commit": "b87502b8dc3a10172e44c390cf7753b8b1fc9b8a"
     }
   },
   "directory": null

--- a/.dockerignore
+++ b/.dockerignore
@@ -9,8 +9,6 @@ __pycache__/
 # Distribution / packaging
 .eggs/
 .installed.cfg
-.pdm-build
-.pdm-python
 .Python
 .python-version
 *.egg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Generate locked requirements.txt
         run: |
-          pdm export --self --output locked-requirements.txt --no-hashes --without dev
+          uv export --no-dev --output locked-requirements.txt --no-hashes
 
       - name: Login to container registry
         uses: docker/login-action@v3
@@ -160,7 +160,7 @@ jobs:
           GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
         run: |
           gh release create ${{ needs.release.outputs.tag }} --generate-notes --latest --verify-tag
-          pdm build --dest dist
+          uv build --out-dir dist
           for filename in dist/*; do
             gh release upload ${{ needs.release.outputs.tag }} ${filename};
           done

--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,6 @@ __pycache__/
 # Distribution / packaging
 .eggs/
 .installed.cfg
-.pdm-build
-.pdm-python
 .Python
 .python-version
 .web/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,16 +24,16 @@ repos:
         name: whitespaces
       - id: fix-byte-order-marker
         name: byte-order
-  - repo: https://github.com/pdm-project/pdm
-    rev: 2.26.1
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    rev: 0.9.21
     hooks:
-      - id: pdm-lock-check
-        name: pdm
+      - id: uv-lock
+        name: uv
   - repo: local
     hooks:
     - id: mypy
       name: mypy
-      entry: pdm run dmypy run --timeout 7200 -- mex tests
+      entry: uv run dmypy run --timeout 7200 -- mex tests
       files: ^(mex|tests)/
       language: system
       pass_filenames: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- updated template to https://github.com/robert-koch-institut/mex-template/commit/b87502
+
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/2039340
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/c5ff3e
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/7c3e75

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ hooks:
 install: setup hooks
 	# install packages from lock file in local virtual environment
 	@ echo installing package; \
-	pdm install-all; \
+	uv sync; \
 
 lint:
 	# run the linter hooks from pre-commit on all files
@@ -67,4 +67,5 @@ start: image
 docs:
 	# use sphinx to auto-generate html docs from code
 	@ echo generating docs; \
-	pdm doc; \
+	uv run sphinx-apidoc -f -o docs/source mex; \
+	uv run sphinx-build -aE -b dirhtml docs docs/dist; \

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ components of the MEx project are open-sourced under the same license as well.
 - update boilerplate files with `cruft update`
 - update global requirements in `requirements.txt` manually
 - update git hooks with `pre-commit autoupdate`
-- update package dependencies using `pdm update-all`
+- update package dependencies using `uv sync --upgrade`
 - update github actions in `.github/workflows/*.yml` manually
 
 ### Creating release
@@ -93,8 +93,8 @@ components of the MEx project are open-sourced under the same license as well.
 
 ## Commands
 
-- run `pdm run {command} --help` to print instructions
-- run `pdm run {command} --debug` for interactive debugging
+- run `uv run {command} --help` to print instructions
+- run `uv run {command} --debug` for interactive debugging
 
 ### editor
 

--- a/mex.bat
+++ b/mex.bat
@@ -25,7 +25,7 @@ if "%CI%"=="" (
 
 @REM install packages from lock file in local virtual environment
 echo installing package
-pdm install-all
+uv sync
 exit /b %errorlevel%
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cruft==2.16.0
 mex-release==1.0.0
-pdm<2.26.2
+uv==0.9.21
 pre-commit==4.5.1


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/b87502

# Conflicts

```diff
diff a/.github/workflows/cve-scan.yml b/.github/workflows/cve-scan.yml	(rejected hunks)
@@ -57,8 +57,8 @@ jobs:
 
       - name: Export dependencies
         run: |
-          mkdir --parents pdm
-          pdm export --group :all --no-hashes -f requirements > pdm/requirements.txt
+          mkdir --parents uv
+          uv export --no-hashes --format requirements-txt --output-file uv/requirements.txt
 
       - name: Run trivy
         uses: aquasecurity/trivy-action@master
```

```diff
diff a/pyproject.toml b/pyproject.toml	(rejected hunks)
@@ -8,7 +8,9 @@ license = { file = "LICENSE" }
 urls = { Repository = "https://github.com/robert-koch-institut/mex-editor" }
 requires-python = ">=3.11,<3.12"
 dependencies = []
-optional-dependencies.dev = [
+
+[dependency-groups]
+dev = [
     "ipdb>=0.13",
     "mypy>=1",
     "pytest-cov>=6",
@@ -35,19 +37,6 @@ show_error_codes = true
 strict = true
 plugins = ["pydantic.mypy"]
 
-[tool.pdm]
-distribution = true
-
-[tool.pdm.scripts]
-update-all = { cmd = "pdm update --group :all --update-all --save-compatible" }
-lock-all = { cmd = "pdm lock --group :all --python='==3.11.*'" }
-install-all = { cmd = "pdm install --group :all --frozen-lockfile" }
-apidoc = { cmd = "pdm run sphinx-apidoc -f -o docs/source mex" }
-sphinx = { cmd = "pdm run sphinx-build -aE -b dirhtml docs docs/dist" }
-doc = { composite = ["apidoc", "sphinx"] }
-lint = { cmd = "pre-commit run --all-files" }
-test = { cmd = "pdm run pytest --numprocesses=auto --dist=worksteal" }
-
 [tool.pydantic-mypy]
 warn_untyped_fields = true
 
```

```diff
diff a/Makefile b/Makefile	(rejected hunks)
@@ -28,17 +28,17 @@ lint:
 unit:
 	# run the test suite with all unit tests
 	@ echo running unit tests; \
-	pdm run pytest -m 'not integration'; \
+	uv run pytest -m 'not integration'; \
 
 test:
 	# run the unit and integration test suites
 	@ echo running all tests; \
-	pdm run pytest --numprocesses=auto --dist=worksteal; \
+	uv run pytest --numprocesses=auto --dist=worksteal; \
 
 wheel:
 	# build the python package
 	@ echo building wheel; \
-	pdm build --no-sdist; \
+	uv build --wheel; \
 
 image:
 	# build the docker image
```

```diff
diff a/mex.bat b/mex.bat	(rejected hunks)
@@ -39,19 +39,20 @@ exit /b %errorlevel%
 :unit
 @REM run the test suite with all unit tests
 echo running unit tests
-pdm run pytest -m "not integration"
+uv run pytest -m "not integration"
 exit /b %errorlevel%
 
 
 :test
 @REM run the unit and integration test suites
 echo running all tests
-pdm run pytest --numprocesses=auto --dist=worksteal
+uv run pytest --numprocesses=auto --dist=worksteal
 exit /b %errorlevel%
 
 
 :docs
 @REM use sphinx to auto-generate html docs from code
 echo generating docs
-pdm doc
+uv run sphinx-apidoc -f -o docs/source mex
+uv run sphinx-build -aE -b dirhtml docs docs/dist
 exit /b %errorlevel%
```
