### PR TITLE
Bump cookiecutter template to 33ca3a

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "ad26e4d983b65dd74f37631a9c0b22a1a601fc3f",
+  "commit": "33ca3a9c40a0fd75a6b82f3ce029d831a4dcd9b9",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -8,7 +8,7 @@
       "short_summary": "Metadata editor web application.",
       "long_summary": "The `mex-editor` is a browser application that allows creating and editing rules to non-destructively manipulate metadata. This can be used to enrich data with manual input or insert new data from scratch.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "ad26e4d983b65dd74f37631a9c0b22a1a601fc3f"
+      "_commit": "33ca3a9c40a0fd75a6b82f3ce029d831a4dcd9b9"
     }
   },
   "directory": null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- updated template to https://github.com/robert-koch-institut/mex-template/commit/33ca3a
+
 - bump python to 3.13
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/ad26e4
 - bump common to 1.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes
 
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/33ca3a
-
 - bump python to 3.13
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/ad26e4
 - bump common to 1.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,4 @@
 cruft==2.16.0
-<<<<<<< ours
-mex-release==1.2.0
-=======
 mex-release==1.2.1
->>>>>>> theirs
 uv==0.9.26
 pre-commit==4.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,8 @@
 cruft==2.16.0
+<<<<<<< ours
 mex-release==1.2.0
+=======
+mex-release==1.2.1
+>>>>>>> theirs
 uv==0.9.26
 pre-commit==4.5.1


### PR DESCRIPTION
### Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/33ca3a
