### PR TITLE
Bump cookiecutter template to 81bc5b

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "33ca3a9c40a0fd75a6b82f3ce029d831a4dcd9b9",
+  "commit": "81bc5b7c81ecd28ca69396d5bfcb3e72daffe968",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -8,7 +8,7 @@
       "short_summary": "Metadata editor web application.",
       "long_summary": "The `mex-editor` is a browser application that allows creating and editing rules to non-destructively manipulate metadata. This can be used to enrich data with manual input or insert new data from scratch.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "33ca3a9c40a0fd75a6b82f3ce029d831a4dcd9b9"
+      "_commit": "81bc5b7c81ecd28ca69396d5bfcb3e72daffe968"
     }
   },
   "directory": null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- updated template to https://github.com/robert-koch-institut/mex-template/commit/81bc5b
+
 ### Deprecated
 
 ### Removed

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   mex-editor:
     build:


### PR DESCRIPTION
### Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/81bc5b
