### PR TITLE
feature/mx-2096-wrap-up-consent-page PaginationMixin

### DIFF
--- a/mex/editor/component_option_helper.py
+++ b/mex/editor/component_option_helper.py
@@ -6,6 +6,7 @@ from mex.editor.pagination_component import (
     PaginationButtonOptions,
     PaginationOptions,
     PaginationPageOptions,
+    PaginationStateMixin,
 )
 from mex.editor.search.state import SearchState
 
@@ -49,6 +50,42 @@ def build_pagination_options(
                 state.refresh,
                 state.resolve_identifiers,
                 *page_load_hooks,
+            ],
+        ),
+    )
+
+
+# TODO(FE): Remove when 'mx-2130-advanced-search-page' is merged
+# and use 'build_pagination_options'
+def build_pagination_options_for_mixin(
+    state: PaginationStateMixin | type[PaginationStateMixin],
+    *page_load_hooks: Callable[[], Any],
+) -> PaginationOptions:
+    """Build pagination options for a PaginationStateMixin."""
+    current_page = cast("Var[int]", state.current_page)
+    hooks = list(page_load_hooks)
+    return PaginationOptions(
+        PaginationButtonOptions(
+            state.disable_previous_page,
+            [
+                state.go_to_previous_page,
+                *hooks,
+            ],
+        ),
+        PaginationButtonOptions(
+            state.disable_next_page,
+            [
+                state.go_to_next_page,
+                *hooks,
+            ],
+        ),
+        PaginationPageOptions(
+            current_page,
+            state.page_selection,
+            state.disable_page_selection,
+            [
+                state.set_current_page,
+                *hooks,
             ],
         ),
     )

--- a/mex/editor/consent/consent_category_list.py
+++ b/mex/editor/consent/consent_category_list.py
@@ -122,9 +122,10 @@ class ConsentCategoryList(State, rx.ComponentState, PaginationStateMixin):
     @rx.event
     def cleanup(self) -> None:
         """Cleanup the component state."""
+        self.category = ""
         self.items = []
-        self.config = None
         self.is_loading = False
+        self.config = None
         self.reset_pagination()  # type: ignore[operator]
 
     @classmethod

--- a/mex/editor/consent/consent_category_list.py
+++ b/mex/editor/consent/consent_category_list.py
@@ -1,0 +1,166 @@
+from collections.abc import Generator
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+import reflex as rx
+from reflex.event import EventSpec
+from requests import HTTPError
+
+from mex.common.backend_api.connector import BackendApiConnector
+from mex.editor.component_option_helper import build_pagination_options_for_mixin
+from mex.editor.consent.state import ConsentState
+from mex.editor.consent.transform import add_external_links_to_results
+from mex.editor.exceptions import escalate_error
+from mex.editor.models import SearchResult
+from mex.editor.pagination_component import PaginationStateMixin, pagination
+from mex.editor.search.transform import transform_models_to_results
+from mex.editor.search_results_component import search_results_list
+from mex.editor.state import State
+from mex.editor.utils import resolve_editor_value
+
+if TYPE_CHECKING:
+    from mex.common.models import AnyPreviewModel
+
+
+@dataclass
+class CategoryListConfig:
+    """Config to store consent category list settings."""
+
+    entity_type: str
+    reference_fields: list[str]
+
+
+CATEGORY_CONFIG: dict[str, CategoryListConfig] = {
+    "resources": CategoryListConfig(
+        "MergedResource", ["contact", "contributor", "creator"]
+    ),
+    "publications": CategoryListConfig(
+        "MergedBibliographicResource", ["creator", "editor", "editorOfSeries"]
+    ),
+    "projects": CategoryListConfig("MergedActivity", ["contact", "involvedPerson"]),
+}
+
+
+class ConsentCategoryList(State, rx.ComponentState, PaginationStateMixin):
+    """ComponentState to show user specific items with pagination."""
+
+    config: CategoryListConfig | None = None
+    category: str = ""
+    is_loading = False
+    items: list[SearchResult] = []
+    limit = 5
+
+    @rx.event
+    def fetch_data(self) -> Generator[EventSpec | None]:
+        """Fetch user-related data based on category."""
+        if not self.merged_login_person or not self.config:
+            yield None
+            return
+
+        connector = BackendApiConnector.get()
+
+        self.is_loading = True
+        yield None
+
+        all_results: list[AnyPreviewModel] = []
+        total = 0
+
+        try:
+            for ref_field in self.config.reference_fields:
+                # TODO(FE): use advanced search method to fetch for multiple refs
+                response = connector.fetch_preview_items(
+                    query_string=None,
+                    entity_type=[self.config.entity_type],
+                    skip=self.skip,
+                    limit=self.limit,
+                    reference_field=ref_field,
+                    referenced_identifier=[str(self.merged_login_person.identifier)],
+                )
+                all_results.extend(response.items)
+                total += response.total
+
+        except HTTPError as exc:
+            self.is_loading = False
+            self.set_current_page(1)  # type:ignore[operator]
+            self.set_total(0)  # type:ignore[operator]
+            self.items = []
+            yield None
+            yield from escalate_error(
+                "backend", "error fetching merged items", exc.response.text
+            )
+            return
+
+        transformed_results = transform_models_to_results(all_results)
+        transformed_results = add_external_links_to_results(transformed_results)
+
+        self.is_loading = False
+        self.set_total(total)  # type:ignore[operator]
+        self.items = transformed_results
+
+    @rx.event(background=True)  # type: ignore[operator]
+    async def resolve_identifiers(self) -> None:
+        """Resolve identifiers to human-readable display values."""
+        for result in self.items:
+            for preview in result.preview:
+                if preview.identifier and not preview.text:
+                    async with self:
+                        await resolve_editor_value(preview)
+
+    @rx.event
+    def initialize(self, category: str) -> Generator[EventSpec | None]:
+        """Initialize the component state."""
+        self.category = category
+        config = CATEGORY_CONFIG.get(category)
+        if not config:
+            err_msg = f"Invalid category {category}."
+            raise ValueError(err_msg)
+        self.config = config
+
+        yield type(self).fetch_data  # type:ignore[misc]
+        yield type(self).resolve_identifiers
+
+    @rx.event
+    def cleanup(self) -> None:
+        """Cleanup the component state."""
+        self.items = []
+        self.config = None
+        self.is_loading = False
+        self.reset_pagination()  # type: ignore[operator]
+
+    @classmethod
+    def get_component(
+        cls, category: Literal["resources", "publications", "projects"]
+    ) -> rx.Component:
+        """Get the category list component."""
+        title = getattr(ConsentState, f"label_{category}_title")
+
+        return rx.fragment(
+            rx.cond(
+                cls.is_loading,
+                rx.spinner(),
+                rx.vstack(
+                    rx.text(
+                        title,
+                        weight="bold",
+                        style=rx.Style(
+                            textTransform="uppercase",
+                        ),
+                    ),
+                    search_results_list(cls.items),
+                    pagination(
+                        build_pagination_options_for_mixin(
+                            cls,
+                            cls.fetch_data(category),  # type:ignore[operator]
+                            cls.resolve_identifiers,
+                        )
+                    ),
+                    style=rx.Style(
+                        textAlign="center",
+                        marginBottom="var(--space-8)",
+                    ),
+                    custom_attrs={"data-testid": f"user-{category}"},
+                ),
+            ),
+            on_mount=cls.initialize(category).debounce(500),  # type:ignore[operator]
+            on_unmount=cls.cleanup,
+        )

--- a/mex/editor/consent/main.py
+++ b/mex/editor/consent/main.py
@@ -1,80 +1,14 @@
-from typing import cast
-
 import reflex as rx
 
+from mex.editor.consent.consent_category_list import ConsentCategoryList
 from mex.editor.consent.layout import page
 from mex.editor.consent.state import ConsentState
-from mex.editor.search_results_component import search_results_list
-
-
-def resources() -> rx.Component:
-    """Render a list of the users resources."""
-    return rx.vstack(
-        rx.text(
-            ConsentState.label_resources_title,
-            weight="bold",
-            style=rx.Style(
-                textTransform="uppercase",
-            ),
-        ),
-        search_results_list(ConsentState.user_resources),
-        consent_pagination("resources"),
-        style=rx.Style(
-            textAlign="center",
-            marginBottom="var(--space-8)",
-        ),
-        custom_attrs={"data-testid": "user-resources"},
-    )
-
-
-def projects() -> rx.Component:
-    """Render a list of the users projects."""
-    return rx.vstack(
-        rx.text(
-            ConsentState.label_projects_title,
-            weight="bold",
-            style=rx.Style(
-                textTransform="uppercase",
-            ),
-        ),
-        search_results_list(ConsentState.user_projects),
-        consent_pagination("projects"),
-        style=rx.Style(
-            textAlign="center",
-            marginBottom="var(--space-4)",
-        ),
-        custom_attrs={"data-testid": "user-projects"},
-    )
-
-
-def publications() -> rx.Component:
-    """Render a list of the users publications."""
-    return rx.vstack(
-        rx.text(
-            ConsentState.label_publications_title,
-            weight="bold",
-            style=rx.Style(
-                textTransform="uppercase",
-            ),
-        ),
-        search_results_list(ConsentState.user_publications),
-        consent_pagination("publications"),
-        style=rx.Style(
-            textAlign="center",
-            marginBottom="var(--space-4)",
-        ),
-        custom_attrs={"data-testid": "user-publications"},
-    )
 
 
 def user_data() -> rx.Component:
     """Render the user data section with name and email."""
     return rx.cond(
-        ConsentState.is_loading,
-        rx.text(
-            ConsentState.label_user_data_loading,
-            custom_attrs={"data-testid": "user-data"},
-        ),
+        ConsentState.merged_login_person,
         rx.vstack(
             rx.text(
                 ConsentState.merged_login_person.full_name,  # type: ignore  [union-attr]
@@ -99,6 +33,10 @@ def user_data() -> rx.Component:
                 textAlign="center",
                 marginBottom="var(--space-4)",
             ),
+            custom_attrs={"data-testid": "user-data"},
+        ),
+        rx.text(
+            ConsentState.label_user_data_loading,
             custom_attrs={"data-testid": "user-data"},
         ),
     )
@@ -173,61 +111,14 @@ def consent_status() -> rx.Component:
     )
 
 
-def consent_pagination(category: str) -> rx.Component:
-    """Render pagination for navigating results dynamically."""
-    return rx.center(
-        rx.button(
-            rx.text(ConsentState.label_pagination_previous_button),
-            on_click=[
-                ConsentState.go_to_previous_page(category),  # type: ignore[operator]
-                ConsentState.scroll_to_top,
-                ConsentState.fetch_data(category),  # type: ignore[operator]
-                ConsentState.resolve_identifiers,
-            ],
-            disabled=getattr(ConsentState, f"disable_{category}_previous_page"),
-            variant="surface",
-            custom_attrs={"data-testid": f"{category}-pagination-previous-button"},
-            style=rx.Style(minWidth="10%"),
-        ),
-        rx.select(
-            getattr(ConsentState, f"{category}_total_pages"),
-            value=cast(
-                "rx.vars.NumberVar", getattr(ConsentState, f"{category}_current_page")
-            ).to_string(),
-            on_change=[
-                getattr(ConsentState, f"set_{category}_page"),
-                ConsentState.scroll_to_top,
-                ConsentState.fetch_data(category),  # type: ignore[operator]
-                ConsentState.resolve_identifiers,
-            ],
-            custom_attrs={"data-testid": f"{category}-pagination-page-select"},
-        ),
-        rx.button(
-            rx.text(ConsentState.label_pagination_next_button),
-            on_click=[
-                ConsentState.go_to_next_page(category),  # type: ignore[operator]
-                ConsentState.scroll_to_top,
-                ConsentState.fetch_data(category),  # type: ignore[operator]
-                ConsentState.resolve_identifiers,
-            ],
-            disabled=getattr(ConsentState, f"disable_{category}_next_page"),
-            variant="surface",
-            custom_attrs={"data-testid": f"{category}-pagination-next-button"},
-            style=rx.Style(minWidth="10%"),
-        ),
-        spacing="4",
-        style=rx.Style(width="100%"),
-    )
-
-
 def index() -> rx.Component:
     """Return the index for the merge and extracted search component."""
     return page(
         rx.vstack(
             user_data(),
-            projects(),
-            resources(),
-            publications(),
+            ConsentCategoryList.create("projects"),
+            ConsentCategoryList.create("resources"),
+            ConsentCategoryList.create("publications"),
             rx.spacer(direction="column"),
             rx.box(
                 consent_box(),

--- a/mex/editor/consent/state.py
+++ b/mex/editor/consent/state.py
@@ -1,19 +1,16 @@
-import math
 from collections.abc import Generator
 from datetime import datetime
 from pathlib import Path
-from typing import Annotated, cast
+from typing import cast
 from zoneinfo import ZoneInfo
 
 import reflex as rx
-from pydantic import Field
 from reflex.event import EventSpec
 from requests import HTTPError
 
 from mex.common.backend_api.connector import BackendApiConnector
 from mex.common.models import (
     AdditiveConsent,
-    AnyPreviewModel,
     AnyRuleSetRequest,
     AnyRuleSetResponse,
     ConsentRuleSetRequest,
@@ -23,54 +20,17 @@ from mex.common.types import (
     ConsentType,
     YearMonthDayTime,
 )
-from mex.editor.consent.transform import add_external_links_to_results
 from mex.editor.exceptions import escalate_error
 from mex.editor.label_var import label_var
 from mex.editor.models import NavItem, SearchResult
 from mex.editor.search.transform import transform_models_to_results
 from mex.editor.state import State
-from mex.editor.utils import resolve_editor_value
-
-CATEGORY_CONFIG = {
-    "resources": {
-        "entity_type": "MergedResource",
-        "reference_fields": ["contact", "contributor", "creator"],
-        "state_list": "user_resources",
-        "state_total": "resources_total",
-        "state_page": "resources_current_page",
-    },
-    "projects": {
-        "entity_type": "MergedActivity",
-        "reference_fields": ["contact", "involvedPerson"],
-        "state_list": "user_projects",
-        "state_total": "projects_total",
-        "state_page": "projects_current_page",
-    },
-    "publications": {
-        "entity_type": "MergedBibliographicResource",
-        "reference_fields": ["creator", "editor", "editorOfSeries"],
-        "state_list": "user_publications",
-        "state_total": "publications_total",
-        "state_page": "publications_current_page",
-    },
-}
 
 
 class ConsentState(State):
     """State for the consent component."""
 
-    user_projects: list[SearchResult] = []
-    user_resources: list[SearchResult] = []
-    user_publications: list[SearchResult] = []
     consent_status: SearchResult | None = None
-    limit: Annotated[int, Field(ge=1, le=100)] = 5
-    projects_total: Annotated[int, Field(ge=0)] = 0
-    projects_current_page: Annotated[int, Field(ge=1)] = 1
-    resources_total: Annotated[int, Field(ge=0)] = 0
-    resources_current_page: Annotated[int, Field(ge=1)] = 1
-    publications_total: Annotated[int, Field(ge=0)] = 0
-    publications_current_page: Annotated[int, Field(ge=1)] = 1
-    is_loading: bool = True
 
     @rx.var
     def _consent_nav_items(self) -> list[NavItem]:
@@ -104,83 +64,6 @@ class ConsentState(State):
         )
 
     @rx.var(cache=False)
-    def disable_projects_previous_page(self) -> bool:
-        """Disable the 'Previous' button if on the first page for projects."""
-        return self.projects_current_page <= 1
-
-    @rx.var(cache=False)
-    def disable_projects_next_page(self) -> bool:
-        """Disable the 'Next' button if on the last page for projects."""
-        max_page = math.ceil(self.projects_total / self.limit)
-        return self.projects_current_page >= max_page
-
-    @rx.var(cache=False)
-    def disable_resources_previous_page(self) -> bool:
-        """Disable the 'Previous' button if on the first page for resources."""
-        return self.resources_current_page <= 1
-
-    @rx.var(cache=False)
-    def disable_resources_next_page(self) -> bool:
-        """Disable the 'Next' button if on the last page for resources."""
-        max_page = math.ceil(self.resources_total / self.limit)
-        return self.resources_current_page >= max_page
-
-    @rx.var(cache=False)
-    def disable_publications_previous_page(self) -> bool:
-        """Disable the 'Previous' button if on the first page for publications."""
-        return self.publications_current_page <= 1
-
-    @rx.var(cache=False)
-    def disable_publications_next_page(self) -> bool:
-        """Disable the 'Next' button if on the last page for publications."""
-        max_page = math.ceil(self.publications_total / self.limit)
-        return self.publications_current_page >= max_page
-
-    @rx.event
-    def go_to_previous_page(self, category: str) -> None:
-        """Navigate to the previous page for any category."""
-        current_page = getattr(self, f"{category}_current_page")
-        setattr(self, f"{category}_current_page", current_page - 1)
-
-    @rx.event
-    def go_to_next_page(self, category: str) -> None:
-        """Navigate to the next page for any category."""
-        current_page = getattr(self, f"{category}_current_page")
-        setattr(self, f"{category}_current_page", current_page + 1)
-
-    @rx.event
-    def set_projects_page(self, page_number: str | int) -> None:
-        """Set the current page for projects."""
-        self.projects_current_page = int(page_number)
-
-    @rx.event
-    def set_resources_page(self, page_number: str | int) -> None:
-        """Set the current page for resources."""
-        self.resources_current_page = int(page_number)
-
-    @rx.event
-    def set_publications_page(self, page_number: str | int) -> None:
-        """Set the current page for publications."""
-        self.publications_current_page = int(page_number)
-
-    @rx.var(cache=False)
-    def projects_total_pages(self) -> list[str]:
-        """Return a list of total pages for projects based on the result count."""
-        return [f"{i + 1}" for i in range(math.ceil(self.projects_total / self.limit))]
-
-    @rx.var(cache=False)
-    def resources_total_pages(self) -> list[str]:
-        """Return a list of total pages for resources based on the result count."""
-        return [f"{i + 1}" for i in range(math.ceil(self.resources_total / self.limit))]
-
-    @rx.var(cache=False)
-    def publications_total_pages(self) -> list[str]:
-        """Return a list of total pages for publications based on the result count."""
-        return [
-            f"{i + 1}" for i in range(math.ceil(self.publications_total / self.limit))
-        ]
-
-    @rx.var(cache=False)
     def consent_datetime(self) -> str:
         """Update datetime for a users consent status."""
         if not self.consent_status:
@@ -189,72 +72,6 @@ class ConsentState(State):
         timestamp_dt = datetime.fromisoformat(str(timestamp_str))
         timestamp_local = timestamp_dt.astimezone(ZoneInfo("Europe/Berlin"))
         return timestamp_local.strftime("%d.%m.%Y um %H:%M")
-
-    @rx.event
-    def get_all_data(self) -> Generator[EventSpec | None]:
-        """Fetch all data for the user."""
-        yield type(self).fetch_data("projects")  # type: ignore[operator]
-        yield type(self).fetch_data("resources")  # type: ignore[operator]
-        yield type(self).fetch_data("publications")  # type: ignore[operator]
-
-    @rx.event
-    def scroll_to_top(self) -> Generator[EventSpec | None]:
-        """Scroll the page to the top."""
-        yield rx.call_script("window.scrollTo({top: 0, behavior: 'smooth'});")
-
-    @rx.event
-    def fetch_data(self, category: str) -> Generator[EventSpec | None]:
-        """Fetch user-related data based on category."""
-        if not self.merged_login_person:
-            yield None
-            return
-
-        connector = BackendApiConnector.get()
-
-        config = CATEGORY_CONFIG.get(category)
-        if not config:
-            msg = f"Unknown category: {category}"
-            raise ValueError(msg)
-
-        current_page = getattr(self, str(config["state_page"]))
-        skip = self.limit * (current_page - 1)
-
-        self.is_loading = True
-        yield None
-
-        all_results: list[AnyPreviewModel] = []
-        total = 0
-
-        try:
-            for ref_field in config["reference_fields"]:
-                response = connector.fetch_preview_items(
-                    query_string=None,
-                    entity_type=[str(config["entity_type"])],
-                    skip=skip,
-                    limit=self.limit,
-                    reference_field=ref_field,
-                    referenced_identifier=[str(self.merged_login_person.identifier)],
-                )
-                all_results.extend(response.items)
-                total += response.total
-
-        except HTTPError as exc:
-            self.is_loading = False
-            setattr(self, str(config["state_page"]), 1)
-            setattr(self, str(config["state_total"]), 0)
-            setattr(self, str(config["state_list"]), [])
-            yield None
-            yield from escalate_error(
-                "backend", "error fetching merged items", exc.response.text
-            )
-            return
-
-        self.is_loading = False
-        transformed_results = transform_models_to_results(all_results)
-        transformed_results = add_external_links_to_results(transformed_results)
-
-        setattr(self, str(config["state_list"]), transformed_results)
-        setattr(self, str(config["state_total"]), total)
 
     @rx.event
     def get_consent(self) -> Generator[EventSpec | None]:
@@ -346,19 +163,6 @@ class ConsentState(State):
                 duration=5000,
             ),
         )
-
-    @rx.event(background=True)  # type: ignore[operator]
-    async def resolve_identifiers(self) -> None:
-        """Resolve identifiers to human-readable display values."""
-        for result_list in (
-            self.user_projects,
-            self.user_resources,
-        ):
-            for result in result_list:
-                for preview in result.preview:
-                    if preview.identifier and not preview.text:
-                        async with self:
-                            await resolve_editor_value(preview)
 
     @label_var(
         label_id="consent.consent_status.consented_format", deps=["consent_datetime"]

--- a/mex/mex.py
+++ b/mex/mex.py
@@ -106,8 +106,6 @@ app.add_page(
     title="MEx Consent",
     on_load=[
         State.check_ldap_login,
-        # ConsentState.get_all_data,
-        # ConsentState.resolve_identifiers,
         ConsentState.get_consent,
     ],
 )

--- a/mex/mex.py
+++ b/mex/mex.py
@@ -106,8 +106,8 @@ app.add_page(
     title="MEx Consent",
     on_load=[
         State.check_ldap_login,
-        ConsentState.get_all_data,
-        ConsentState.resolve_identifiers,
+        # ConsentState.get_all_data,
+        # ConsentState.resolve_identifiers,
         ConsentState.get_consent,
     ],
 )

--- a/rxconfig.py
+++ b/rxconfig.py
@@ -5,4 +5,4 @@ config = rx.Config(
     disable_plugins=["reflex.plugins.sitemap.SitemapPlugin"],
     tailwind=None,
     telemetry_enabled=False,
-)
+)  # type: ignore[no-untyped-call]

--- a/tests/consent/test_main.py
+++ b/tests/consent/test_main.py
@@ -34,6 +34,7 @@ def consent_page(
     page.goto(f"{base_url}/consent")
     page_body = page.get_by_test_id("page-body")
     expect(page_body).to_be_visible()
+    page.wait_for_timeout(5000)
     page.screenshot(path="tests_consent_test_main-test_index-on-load.png")
     return page
 
@@ -55,10 +56,14 @@ def test_projects_and_resources(consent_page: Page) -> None:
 def test_pagination(consent_page: Page) -> None:
     page = consent_page
 
-    pagination_previous = page.get_by_test_id("resources-pagination-previous-button")
-    pagination_next = page.get_by_test_id("resources-pagination-next-button")
-    pagination_page_select = page.get_by_test_id("resources-pagination-page-select")
+    res_list = page.get_by_test_id("user-resources")
+    pagination_previous = res_list.get_by_test_id("pagination-previous-button")
+    pagination_next = res_list.get_by_test_id("pagination-next-button")
+    pagination_page_select = res_list.get_by_test_id("pagination-page-select")
+    res_list.highlight()
 
+    page.screenshot(path="tests_consent_test_main_test_pagination.png")
+    pagination_previous.scroll_into_view_if_needed()
     pagination_page_select.scroll_into_view_if_needed()
     page.screenshot(path="tests_consent_test_main_test_pagination.png")
 

--- a/tests/consent/test_main.py
+++ b/tests/consent/test_main.py
@@ -60,10 +60,7 @@ def test_pagination(consent_page: Page) -> None:
     pagination_previous = res_list.get_by_test_id("pagination-previous-button")
     pagination_next = res_list.get_by_test_id("pagination-next-button")
     pagination_page_select = res_list.get_by_test_id("pagination-page-select")
-    res_list.highlight()
 
-    page.screenshot(path="tests_consent_test_main_test_pagination.png")
-    pagination_previous.scroll_into_view_if_needed()
     pagination_page_select.scroll_into_view_if_needed()
     page.screenshot(path="tests_consent_test_main_test_pagination.png")
 


### PR DESCRIPTION
### PR Context
We introduced a state mixin for pagination that makes the pagination logic reusable (or at least tries). This PR is a try to use this mixin within the consent page along the different categories.

### Added
- ConsentCategoryList: ComponentState to use the PageinationStateMixin to handle the different category lists

### Changes
- Removes the pagination und fetching logik from the consent page and moved it the new ConsentCategoryList
