### PR TITLE
hotfix/mx-2172 Scripts Bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- all custom scripts due to reflex docs
+
 ### Fixed
 
 ### Security

--- a/mex/editor/layout.py
+++ b/mex/editor/layout.py
@@ -274,19 +274,6 @@ def nav_bar(nav_items_source: list[NavItem] | None = None) -> rx.Component:
     )
 
 
-def custom_focus_script() -> rx.Script:
-    """Creates a Script that looks for '[data-focusme]' and calls '.focus()' in it."""
-    return rx.script(
-        """
-    (function() {
-        document.querySelectorAll('[data-focusme]').forEach(item=> {
-            setTimeout(() => item.focus(), 10);
-        })
-    })()
-    """
-    )
-
-
 def page(
     *children: rx.Component,
     user_type: str = "user_mex",
@@ -315,7 +302,6 @@ def page(
             custom_attrs={"data-testid": "page-body"},
         ),
         unsaved_changes_dialog(),
-        custom_focus_script(),
     ]
 
     return rx.cond(

--- a/mex/editor/login/main.py
+++ b/mex/editor/login/main.py
@@ -1,7 +1,7 @@
 import reflex as rx
 from reflex.event import EventType
 
-from mex.editor.layout import app_logo, custom_focus_script
+from mex.editor.layout import app_logo  # , custom_focus_script
 from mex.editor.login.state import LoginLdapState, LoginMExState, LoginState
 
 
@@ -11,12 +11,13 @@ def login_user() -> rx.Component:
         rx.text(LoginState.label_username),
         rx.input(
             name="username",
+            auto_focus=True,
             on_change=LoginState.set_username,
             placeholder=LoginState.label_username,
             size="3",
             tab_index=1,
             style=rx.Style(width="100%"),
-            custom_attrs={"data-testid": "input-username", "data-focusme": ""},
+            custom_attrs={"data-testid": "input-username"},
         ),
         style=rx.Style(width="100%"),
     )
@@ -86,7 +87,6 @@ def login_form(login_callback: EventType[()]) -> rx.Component:
                     on_submit=login_callback,
                     spacing="4",
                 ),
-                custom_focus_script(),
             ),
             style=rx.Style(
                 width="calc(340px * var(--scaling))",

--- a/mex/editor/search_reference_dialog.py
+++ b/mex/editor/search_reference_dialog.py
@@ -7,7 +7,6 @@ from requests import HTTPError
 from mex.common.backend_api.connector import BackendApiConnector
 from mex.editor.exceptions import escalate_error
 from mex.editor.label_var import label_var
-from mex.editor.layout import custom_focus_script
 from mex.editor.locale_service import LocaleService
 from mex.editor.models import SearchResult
 from mex.editor.pagination_component import (
@@ -200,7 +199,6 @@ def search_reference_dialog(
                 value=SearchReferenceDialogState.user_query,
                 on_change=SearchReferenceDialogState.set_user_query,
                 custom_attrs={
-                    "data-focusme": "",
                     "data-testid": f"{component_id_prefix}-query-input",
                 },
                 placeholder=SearchReferenceDialogState.label_query_placeholder,
@@ -282,7 +280,6 @@ def search_reference_dialog(
                 render_result(),
                 align="stretch",
             ),
-            custom_focus_script(),
             style=rx.Style({"max-width": "62vw !important"}),
             on_open_auto_focus=[
                 SearchReferenceDialogState.set_user_query(""),  # type: ignore[operator]


### PR DESCRIPTION
### PR Context
Reflex [docs](https://reflex.dev/docs/api-reference/browser-javascript/) suggest to not use custom javascript.

> Custom Javascript code in your Reflex app presents a maintenance challenge, as it will be harder to debug and may be unstable across Reflex versions.
>Prefer to use the Python API whenever possible and file an issue if you need additional functionality that is not currently provided.

### Removed
- all custom scripts are removed

