### PR TITLE
feature/mx-1941-set-primary-source-of-rules-to-editor

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -35,7 +35,7 @@ jobs:
         ports:
           - 7687:7687
       backend:
-        image: ghcr.io/robert-koch-institut/mex-backend:1.4.0
+        image: ghcr.io/robert-koch-institut/mex-backend:1.6.0
         env:
           MEX_BACKEND_API_USER_DATABASE: ${{ secrets.MEX_BACKEND_API_USER_DATABASE }}
           MEX_BACKEND_API_KEY_DATABASE: ${{ secrets.MEX_BACKEND_API_KEY_DATABASE }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes
 
 - change primary source of rules from mex to mex-editor
+- moved pytest rerun config from toml to makefile
 
 ### Deprecated
 
@@ -21,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - fixed width of search and advanced-search result lists
 - fixed redirect target after login screen interception
-- fixed duplicate settings logging on startup
+- fixed settings logging on startup and in tests
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- change primary source of rules from mex to mex-editor
+
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - fixed width of search and advanced-search result lists
 - fixed redirect target after login screen interception
+- fixed duplicate settings logging on startup
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- fixed settings logging on startup and in tests
+
 ### Security
 
 ## [1.5.1] - 2026-02-25
@@ -28,7 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - fixed width of search and advanced-search result lists
 - fixed redirect target after login screen interception
-- fixed settings logging on startup and in tests
 
 ## [1.5.0] - 2026-02-24
 

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ unit:
 test:
 	# run the unit and integration test suites
 	@ echo running all tests; \
-	uv run pytest -m 'not requires_rki_infrastructure'; \
+	uv run pytest -m 'not requires_rki_infrastructure' --reruns=2; \
 
 wheel:
 	# build the python package

--- a/mex/editor/rules/transform.py
+++ b/mex/editor/rules/transform.py
@@ -302,7 +302,7 @@ def _transform_fields_to_additive(
             continue
         field_values = raw_rule.setdefault(field.name, [])
         for primary_source in field.primary_sources:
-            if primary_source.identifier != MEX_PRIMARY_SOURCE_STABLE_TARGET_ID:
+            if primary_source.identifier != MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID:
                 continue
             for editor_value in primary_source.editor_values:
                 additive_value = _transform_editor_value_to_model_value(

--- a/mex/editor/rules/transform.py
+++ b/mex/editor/rules/transform.py
@@ -15,6 +15,7 @@ from mex.common.fields import (
     VOCABULARY_FIELDS_BY_CLASS_NAME,
 )
 from mex.common.models import (
+    MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID,
     MEX_PRIMARY_SOURCE_STABLE_TARGET_ID,
     RULE_SET_REQUEST_CLASSES_BY_NAME,
     AnyAdditiveModel,
@@ -62,8 +63,10 @@ def _get_primary_source_id_from_model(
     """Given any model type, try to derive a sensible primary source identifier."""
     if isinstance(model, AnyExtractedModel):
         return MergedPrimarySourceIdentifier(model.hadPrimarySource)
-    if isinstance(model, AnyMergedModel | AnyRuleModel):
+    if isinstance(model, AnyMergedModel):
         return MEX_PRIMARY_SOURCE_STABLE_TARGET_ID
+    if isinstance(model, AnyRuleModel):
+        return MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID
     msg = (
         "Cannot get primary source ID for model. Expected ExtractedModel, "
         f"MergedModel or RuleModel, got {type(model)}."

--- a/mex/editor/utils.py
+++ b/mex/editor/utils.py
@@ -5,7 +5,9 @@ from async_lru import alru_cache
 
 from mex.common.backend_api.connector import BackendApiConnector
 from mex.common.exceptions import EmptySearchResultError, MExError
+from mex.common.settings import SETTINGS_STORE
 from mex.editor.models import EditorValue
+from mex.editor.settings import EditorSettings
 from mex.editor.transform import transform_models_to_title
 
 
@@ -29,6 +31,12 @@ async def resolve_editor_value(editor_value: EditorValue) -> None:
     else:
         msg = f"Cannot resolve editor value: {editor_value}"
         raise MExError(msg)
+
+
+def load_settings() -> EditorSettings:
+    """Reset the settings store and fetch the editor settings."""
+    SETTINGS_STORE.reset()
+    return EditorSettings.get()
 
 
 def replace_url_params(

--- a/mex/editor/utils.py
+++ b/mex/editor/utils.py
@@ -5,9 +5,7 @@ from async_lru import alru_cache
 
 from mex.common.backend_api.connector import BackendApiConnector
 from mex.common.exceptions import EmptySearchResultError, MExError
-from mex.common.settings import SETTINGS_STORE
 from mex.editor.models import EditorValue
-from mex.editor.settings import EditorSettings
 from mex.editor.transform import transform_models_to_title
 
 
@@ -31,12 +29,6 @@ async def resolve_editor_value(editor_value: EditorValue) -> None:
     else:
         msg = f"Cannot resolve editor value: {editor_value}"
         raise MExError(msg)
-
-
-def load_settings() -> EditorSettings:
-    """Reset the settings store and fetch the editor settings."""
-    SETTINGS_STORE.reset()
-    return EditorSettings.get()
 
 
 def replace_url_params(

--- a/mex/mex.py
+++ b/mex/mex.py
@@ -20,6 +20,7 @@ from mex.editor.rules.state import RuleState
 from mex.editor.search.main import index as search_index
 from mex.editor.search.state import SearchState
 from mex.editor.state import State
+from mex.editor.utils import load_settings
 
 app = rx.App(
     theme=themes.theme(accent_color="blue", has_background=False),
@@ -135,4 +136,7 @@ app.add_page(
         ConsentState.resolve_identifiers,
         ConsentState.get_consent,
     ],
+)
+app.register_lifespan_task(
+    load_settings,
 )

--- a/mex/mex.py
+++ b/mex/mex.py
@@ -1,8 +1,6 @@
 import reflex as rx
 from reflex.components.radix import themes
-from reflex.utils.console import info as log_info
 
-from mex.common.logging import logger
 from mex.editor.advanced_search.main import index as advanced_search_index
 from mex.editor.advanced_search.state import AdvancedSearchState
 from mex.editor.api.main import api as editor_api
@@ -22,7 +20,6 @@ from mex.editor.rules.state import RuleState
 from mex.editor.search.main import index as search_index
 from mex.editor.search.state import SearchState
 from mex.editor.state import State
-from mex.editor.utils import load_settings
 
 app = rx.App(
     theme=themes.theme(accent_color="blue", has_background=False),
@@ -118,8 +115,16 @@ app.add_page(
         IngestState.flag_ingested_items,
     ],
 )
-app.add_page(login_mex_index, route="/login", title="MEx Editor | Login")
-app.add_page(login_ldap_index, route="/login-ldap", title="MEx Editor | Login")
+app.add_page(
+    login_mex_index,
+    route="/login",
+    title="MEx Editor | Login",
+)
+app.add_page(
+    login_ldap_index,
+    route="/login-ldap",
+    title="MEx Editor | Login",
+)
 app.add_page(
     consent_index,
     route="/consent",
@@ -130,11 +135,4 @@ app.add_page(
         ConsentState.resolve_identifiers,
         ConsentState.get_consent,
     ],
-)
-app.register_lifespan_task(
-    lambda: logger.info(load_settings().text()),
-)
-app.register_lifespan_task(
-    log_info,
-    msg="MEx Editor is running, shut it down using CTRL+C",
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,6 @@ addopts = [
     "--pdbcls=IPython.terminal.debugger:TerminalPdb",
     "--capture=no", # https://github.com/pytest-dev/pytest/issues/2064#issuecomment-421812955
     "--random-order-bucket=global",
-    "--reruns=2",
 ]
 markers = [
     "integration: mark a test as integration test",

--- a/tests/advanced_search/test_main.py
+++ b/tests/advanced_search/test_main.py
@@ -61,9 +61,9 @@ def test_query_filter(advanced_search_page: Page) -> None:
 @pytest.mark.parametrize(
     ("entity_types", "expected_count"),
     [
-        pytest.param([MergedPrimarySource.stemType], 3),
+        pytest.param([MergedPrimarySource.stemType], 4),
         pytest.param([MergedResource.stemType], 2),
-        pytest.param([MergedPrimarySource.stemType, MergedResource.stemType], 5),
+        pytest.param([MergedPrimarySource.stemType, MergedResource.stemType], 6),
     ],
 )
 @pytest.mark.integration
@@ -126,7 +126,7 @@ def test_reference_filter_one_field_filter(
     page.get_by_test_id("filter-ref-0-value-0-remove").click()
     page.get_by_test_id("ref-filter-0-remove").click()
     _make_screenshot(page, "test_reference_filter_one_field_filter_cleanup")
-    expect(page.get_by_test_id(search_result_item_regex)).to_have_count(9)
+    expect(page.get_by_test_id(search_result_item_regex)).to_have_count(10)
 
 
 @pytest.mark.parametrize(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from collections.abc import Generator
 from re import Pattern
@@ -7,10 +8,11 @@ import pytest
 from fastapi.testclient import TestClient
 from playwright.sync_api import Page, expect
 from pydantic import SecretStr
-from pytest import MonkeyPatch
+from pytest import LogCaptureFixture
 
 from mex.artificial.helpers import generate_artificial_extracted_items
 from mex.common.backend_api.connector import BackendApiConnector
+from mex.common.logging import logger
 from mex.common.models import (
     EXTRACTED_MODEL_CLASSES_BY_NAME,
     MEX_PRIMARY_SOURCE_STABLE_TARGET_ID,
@@ -64,47 +66,30 @@ def client() -> TestClient:
 
 
 @pytest.fixture(autouse=True)
-def settings() -> EditorSettings:
-    """Load and return the current editor settings."""
-    return EditorSettings.get()
-
-
-@pytest.fixture(autouse=True)
-def set_identity_provider(
+def settings(
+    caplog: LogCaptureFixture,
+    request: pytest.FixtureRequest,
     is_integration_test: bool,  # noqa: FBT001
-    monkeypatch: MonkeyPatch,
-) -> None:
-    """Ensure the identifier provider is set correctly for unit and int tests."""
-    # TODO(ND): clean this up after MX-1708
-    settings = EditorSettings.get()
-    if is_integration_test:
-        monkeypatch.setitem(settings.model_config, "validate_assignment", False)  # noqa: FBT003
-        monkeypatch.setattr(settings, "identity_provider", IdentityProvider.BACKEND)
-    else:
-        monkeypatch.setattr(settings, "identity_provider", IdentityProvider.MEMORY)
-
-
-@pytest.fixture(autouse=True)
-def patch_editor_user_database(
-    is_integration_test: bool,  # noqa: FBT001
-    monkeypatch: MonkeyPatch,
-    settings: EditorSettings,
-) -> None:
-    """Overwrite the user database with dummy credentials."""
-    if not is_integration_test:
-        monkeypatch.setattr(
-            settings,
-            "editor_user_database",
-            EditorUserDatabase(
+    isolate_settings: None,  # noqa: ARG001
+) -> EditorSettings:
+    """Load and return the correct editor settings."""
+    verbosity = request.config.option.verbose
+    cutoff_level = logging.INFO if verbosity >= 2 else logging.WARNING
+    with caplog.at_level(cutoff_level, logger=logger.name):
+        settings = EditorSettings.get()
+        if is_integration_test:
+            settings.identity_provider = IdentityProvider.BACKEND
+        else:
+            settings.identity_provider = IdentityProvider.MEMORY
+            settings.editor_user_database = EditorUserDatabase(
                 read={"reader": EditorUserPassword("reader_pass")},
                 write={"writer": EditorUserPassword("writer_pass")},
-            ),
-        )
+            )
+    return settings
 
 
 @pytest.fixture
-def writer_user_credentials() -> tuple[str, SecretStr]:
-    settings = EditorSettings.get()
+def writer_user_credentials(settings: EditorSettings) -> tuple[str, SecretStr]:
     for username, password in settings.editor_user_database["write"].items():
         return username, password
     msg = "No writer configured"  # pragma: no cover
@@ -354,6 +339,8 @@ def build_pagination_regex(current: int, total: int) -> Pattern[str]:
 
 def build_ui_label_regex(label_id: str) -> Pattern[str]:
     service = LocaleService.get()
-    return re.compile(
-        f"({'|'.join(re.escape(service.get_ui_label(locale.id, label_id)) for locale in service.get_available_locales())})"
+    ui_labels = (
+        re.escape(service.get_ui_label(locale.id, label_id))
+        for locale in service.get_available_locales()
     )
+    return re.compile(f"({'|'.join(ui_labels)})")

--- a/tests/create/test_main.py
+++ b/tests/create/test_main.py
@@ -6,7 +6,10 @@ from playwright.sync_api import Locator, Page, expect
 
 from mex.common.backend_api.connector import BackendApiConnector
 from mex.common.fields import MERGEABLE_FIELDS_BY_CLASS_NAME
-from mex.common.models import AnyExtractedModel
+from mex.common.models import (
+    MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID,
+    AnyExtractedModel,
+)
 from tests.conftest import build_ui_label_regex
 
 url_regex = re.compile(r"/create/(\w+)")
@@ -104,7 +107,9 @@ def test_create_page_renders_fields(create_page: Page) -> None:
 @pytest.mark.integration
 def test_create_page_test_additive_buttons(create_page: Page) -> None:
     page = create_page
-    new_additive_button = page.get_by_test_id("new-additive-description-00000000000000")
+    new_additive_button = page.get_by_test_id(
+        f"new-additive-description-{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}"
+    )
     new_additive_button.scroll_into_view_if_needed()
     page.screenshot(
         path="tests_create_test_main-test_edit_page_renders_new_additive_button.png"
@@ -127,7 +132,9 @@ def test_create_page_test_additive_buttons(create_page: Page) -> None:
 @pytest.mark.integration
 def test_create_page_submit_item(create_page: Page) -> None:
     page = create_page
-    new_additive_button = page.get_by_test_id("new-additive-title-00000000000000")
+    new_additive_button = page.get_by_test_id(
+        f"new-additive-title-{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}"
+    )
     new_additive_button.scroll_into_view_if_needed()
     expect(new_additive_button).to_be_visible()
     new_additive_button.click()
@@ -195,7 +202,9 @@ def test_search_reference_dialog(
 ) -> None:
     dialog_prefix = "search-reference-dialog"
     field_contact = create_page.get_by_test_id("field-contact")
-    field_contact.get_by_test_id("new-additive-contact-00000000000000").click()
+    field_contact.get_by_test_id(
+        f"new-additive-contact-{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}"
+    ).click()
     field_contact.get_by_test_id(f"{dialog_prefix}-button").click()
 
     query_input = create_page.get_by_test_id(f"{dialog_prefix}-query-input")
@@ -216,7 +225,9 @@ def test_search_reference_dialog(
     ).to_have_value(ou.stableTargetId)
 
     field_uic = create_page.get_by_test_id("field-unitInCharge")
-    field_uic.get_by_test_id("new-additive-unitInCharge-00000000000000").click()
+    field_uic.get_by_test_id(
+        f"new-additive-unitInCharge-{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}"
+    ).click()
     field_uic.get_by_test_id(f"{dialog_prefix}-button").click()
     expect(search_results.locator(".search-result-card")).to_have_count(1)
     create_page.locator(".rt-DialogOverlay").click(position={"x": 10, "y": 10})
@@ -248,7 +259,9 @@ def test_create_page_test_draft_creation_on_field_edit(
 ) -> None:
     create_page = draft_create_page["page"]
 
-    create_page.get_by_test_id("new-additive-title-00000000000000").click()
+    create_page.get_by_test_id(
+        f"new-additive-title-{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}"
+    ).click()
     expect(draft_create_page["discard_dialog_button"]).to_be_visible()
     expect(draft_create_page["draft_menu_trigger"]).to_have_text("1")
     draft_create_page["draft_menu_trigger"].click()
@@ -261,7 +274,9 @@ def test_create_page_test_discard_draft(
 ) -> None:
     create_page = draft_create_page["page"]
 
-    create_page.get_by_test_id("new-additive-title-00000000000000").click()
+    create_page.get_by_test_id(
+        f"new-additive-title-{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}"
+    ).click()
     create_page.get_by_test_id("additive-rule-title-0-text").fill(
         "Draft title for activity"
     )
@@ -286,7 +301,9 @@ def test_logout_unsaved_changes_dialog_on_draft_logout_normal(
         )
 
     # create and add contact there should be a draft
-    page.get_by_test_id("new-additive-contact-00000000000000").click()
+    page.get_by_test_id(
+        f"new-additive-contact-{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}"
+    ).click()
     expect(page.get_by_test_id("draft-menu-trigger")).to_be_visible()
     _screenshot("changes")
 
@@ -327,7 +344,9 @@ def test_logout_unsaved_changes_dialog_on_draft(draft_create_page: DraftPage) ->
         )
 
     # create and add contact there should be a draft
-    page.get_by_test_id("new-additive-contact-00000000000000").click()
+    page.get_by_test_id(
+        f"new-additive-contact-{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}"
+    ).click()
     expect(page.get_by_test_id("draft-menu-trigger")).to_be_visible()
     _screenshot("changes")
 
@@ -350,7 +369,9 @@ def test_create_page_test_draft_menu_item_text(
 ) -> None:
     create_page = draft_create_page["page"]
 
-    create_page.get_by_test_id("new-additive-description-00000000000000").click()
+    create_page.get_by_test_id(
+        f"new-additive-description-{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}"
+    ).click()
     create_page.get_by_test_id("additive-rule-description-0-text").fill(
         "New Description."
     )
@@ -362,7 +383,9 @@ def test_create_page_test_draft_menu_item_text(
     expect(draft_create_page["draft_menu_item"]).to_have_text("AccessPlatform")
     # force the menu overlay to close
     create_page.mouse.click(10, 10)
-    create_page.get_by_test_id("new-additive-title-00000000000000").click()
+    create_page.get_by_test_id(
+        f"new-additive-title-{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}"
+    ).click()
     create_page.get_by_test_id("additive-rule-title-0-text").fill(
         "Draft title for access platform"
     )

--- a/tests/edit/test_main.py
+++ b/tests/edit/test_main.py
@@ -7,6 +7,7 @@ from playwright.sync_api import Page, expect
 from mex.common.backend_api.connector import BackendApiConnector
 from mex.common.fields import MERGEABLE_FIELDS_BY_CLASS_NAME
 from mex.common.models import (
+    MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID,
     ActivityRuleSetRequest,
     AdditiveActivity,
     AdditiveContactPoint,
@@ -359,7 +360,7 @@ def test_edit_page_switch_roundtrip(
 def test_edit_page_renders_new_additive_button(edit_page: Page) -> None:
     page = edit_page
     new_additive_button = page.get_by_test_id(
-        "new-additive-fundingProgram-00000000000000"
+        f"new-additive-fundingProgram-{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}"
     )
     new_additive_button.scroll_into_view_if_needed()
     page.screenshot(
@@ -377,7 +378,7 @@ def test_edit_page_renders_new_additive_button(edit_page: Page) -> None:
 def test_edit_page_renders_remove_additive_button(edit_page: Page) -> None:
     page = edit_page
     new_additive_button = page.get_by_test_id(
-        "new-additive-fundingProgram-00000000000000"
+        f"new-additive-fundingProgram-{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}"
     )
     new_additive_button.scroll_into_view_if_needed()
     page.screenshot(
@@ -395,7 +396,9 @@ def test_edit_page_renders_remove_additive_button(edit_page: Page) -> None:
 @pytest.mark.integration
 def test_edit_page_renders_text_input(edit_page: Page) -> None:
     page = edit_page
-    new_additive_button = page.get_by_test_id("new-additive-shortName-00000000000000")
+    new_additive_button = page.get_by_test_id(
+        f"new-additive-shortName-{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}"
+    )
     new_additive_button.scroll_into_view_if_needed()
     expect(new_additive_button).to_be_visible()
     new_additive_button.click()
@@ -411,7 +414,7 @@ def test_edit_page_renders_text_input(edit_page: Page) -> None:
 def test_edit_page_renders_textarea_input(edit_page: Page) -> None:
     page = edit_page
     new_additive_button = page.get_by_test_id(
-        "new-additive-alternativeTitle-00000000000000"
+        f"new-additive-alternativeTitle-{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}"
     )
     new_additive_button.scroll_into_view_if_needed()
     expect(new_additive_button).to_be_visible()
@@ -432,7 +435,7 @@ def test_edit_page_renders_textarea_input(edit_page: Page) -> None:
 def test_edit_page_renders_identifier_input(edit_page: Page) -> None:
     page = edit_page
     new_additive_button = page.get_by_test_id(
-        "new-additive-involvedUnit-00000000000000"
+        f"new-additive-involvedUnit-{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}"
     )
     new_additive_button.scroll_into_view_if_needed()
     expect(new_additive_button).to_be_visible()
@@ -452,7 +455,7 @@ def test_edit_page_resolves_additive_identifier(
 ) -> None:
     page = edit_page
     new_additive_button = page.get_by_test_id(
-        "new-additive-involvedUnit-00000000000000"
+        f"new-additive-involvedUnit-{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}"
     )
     new_additive_button.scroll_into_view_if_needed()
     expect(new_additive_button).to_be_visible()
@@ -463,7 +466,9 @@ def test_edit_page_resolves_additive_identifier(
     identifier_input = page.get_by_test_id("additive-rule-involvedUnit-0-identifier")
     expect(identifier_input).to_be_visible()
     identifier_input.fill(organizational_unit.stableTargetId)
-    edit_button = page.get_by_test_id("edit-toggle-involvedUnit-00000000000000-0")
+    edit_button = page.get_by_test_id(
+        f"edit-toggle-involvedUnit-{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}-0"
+    )
     edit_button.click()
 
     # verify identifier is correctly rendered
@@ -487,7 +492,9 @@ def test_edit_page_resolves_additive_identifier(
 @pytest.mark.integration
 def test_edit_page_renders_link_input(edit_page: Page) -> None:
     page = edit_page
-    new_additive_button = page.get_by_test_id("new-additive-website-00000000000000")
+    new_additive_button = page.get_by_test_id(
+        f"new-additive-website-{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}"
+    )
     new_additive_button.scroll_into_view_if_needed()
     expect(new_additive_button).to_be_visible()
     new_additive_button.click()
@@ -505,7 +512,7 @@ def test_edit_page_renders_link_input(edit_page: Page) -> None:
 def test_edit_page_renders_vocabulary_input(edit_page: Page) -> None:
     page = edit_page
     new_additive_button = page.get_by_test_id(
-        "new-additive-activityType-00000000000000"
+        f"new-additive-activityType-{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}"
     )
     new_additive_button.scroll_into_view_if_needed()
     expect(new_additive_button).to_be_visible()
@@ -535,7 +542,9 @@ def test_edit_page_renders_vocabulary_input(edit_page: Page) -> None:
 @pytest.mark.integration
 def test_edit_page_renders_temporal_input(edit_page: Page) -> None:
     page = edit_page
-    new_additive_button = page.get_by_test_id("new-additive-end-00000000000000")
+    new_additive_button = page.get_by_test_id(
+        f"new-additive-end-{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}"
+    )
     new_additive_button.scroll_into_view_if_needed()
     expect(new_additive_button).to_be_visible()
     new_additive_button.click()
@@ -564,7 +573,9 @@ def test_edit_page_additive_rule_roundtrip(
     test_id = "tests_edit_test_main-test_edit_page_additive_rule_roundtrip"
 
     # click button for new additive rule on contact field
-    new_additive_button = page.get_by_test_id("new-additive-contact-00000000000000")
+    new_additive_button = page.get_by_test_id(
+        f"new-additive-contact-{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}"
+    )
     new_additive_button.scroll_into_view_if_needed()
     page.screenshot(path=f"{test_id}-on_load.png")
     expect(new_additive_button).to_be_visible()
@@ -602,7 +613,9 @@ def test_edit_page_additive_rule_roundtrip(
     expect(additive_rule_rendered).to_be_visible()
 
     # click edit button
-    edit_button = page.get_by_test_id("edit-toggle-contact-00000000000000-0")
+    edit_button = page.get_by_test_id(
+        f"edit-toggle-contact-{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}-0"
+    )
     edit_button.scroll_into_view_if_needed()
     page.screenshot(path=f"{test_id}-on_load.png")
     expect(edit_button).to_be_visible()
@@ -716,7 +729,9 @@ def test_toggle_all_switch(edit_page: Page) -> None:
 
 @pytest.mark.integration
 def test_edit_page_submit_button_disabled_while_submitting(edit_page: Page) -> None:
-    edit_page.get_by_test_id("new-additive-alternativeTitle-00000000000000").click()
+    edit_page.get_by_test_id(
+        f"new-additive-alternativeTitle-{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}"
+    ).click()
     edit_page.get_by_test_id("additive-rule-alternativeTitle-0-text").fill(
         "new alternative title"
     )
@@ -774,7 +789,7 @@ def test_edit_page_additive_add_remove_button_text_translation(
     edit_page.get_by_test_id("language-switcher").click()
     edit_page.get_by_test_id(f"language-switcher-menu-item-{locale_id}").click()
     add_alt_title_btn = edit_page.get_by_test_id(
-        f"new-additive-{field_name}-00000000000000"
+        f"new-additive-{field_name}-{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}"
     )
     expect(add_alt_title_btn).to_have_text(re.compile(f"{expected_field_label}"))
     add_alt_title_btn.click()
@@ -792,7 +807,9 @@ def test_edit_page_discard_changes_button_roundtrip(
     expect(discard_dialog_button).not_to_be_visible()
 
     # add/remove new alternative title and check button visibility
-    edit_page.get_by_test_id("new-additive-alternativeTitle-00000000000000").click()
+    edit_page.get_by_test_id(
+        f"new-additive-alternativeTitle-{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}"
+    ).click()
     edit_page.get_by_test_id("additive-rule-alternativeTitle-0-text").fill(
         "new added alternative title"
     )
@@ -801,7 +818,9 @@ def test_edit_page_discard_changes_button_roundtrip(
     expect(discard_dialog_button).not_to_be_visible()
 
     # add new alternative title, save and check button visibility
-    edit_page.get_by_test_id("new-additive-alternativeTitle-00000000000000").click()
+    edit_page.get_by_test_id(
+        f"new-additive-alternativeTitle-{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}"
+    ).click()
     edit_page.get_by_test_id("additive-rule-alternativeTitle-0-text").fill(
         "new saved added alternative title"
     )
@@ -839,7 +858,9 @@ def test_edit_page_discard_changes_button_roundtrip(
     expect(discard_dialog_button).not_to_be_visible()
 
     # do changes navigate away, come back and check if changes still present, discard change
-    edit_page.get_by_test_id("new-additive-shortName-00000000000000").click()
+    edit_page.get_by_test_id(
+        f"new-additive-shortName-{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}"
+    ).click()
     shortname_text = edit_page.get_by_test_id("additive-rule-shortName-0-text")
     shortname_text.fill("shortNameChanges")
     # give the state some time to sync changes into local storage

--- a/tests/rules/test_state.py
+++ b/tests/rules/test_state.py
@@ -1,7 +1,7 @@
 import pytest
 
 from mex.common.models import (
-    MEX_PRIMARY_SOURCE_STABLE_TARGET_ID,
+    MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID,
     ContactPointRuleSetResponse,
     ExtractedContactPoint,
 )
@@ -45,10 +45,10 @@ def test_state_get_primary_sources_by_field_name() -> None:
         ),
         EditorPrimarySource(
             name=EditorValue(
-                identifier=MEX_PRIMARY_SOURCE_STABLE_TARGET_ID,
-                href="/item/{MEX_PRIMARY_SOURCE_STABLE_TARGET_ID}",
+                identifier=MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID,
+                href=f"/item/{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}",
             ),
-            identifier=MEX_PRIMARY_SOURCE_STABLE_TARGET_ID,
+            identifier=MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID,
             input_config=InputConfig(editable_text=True, allow_additive=True),
             editor_values=[],
             enabled=True,

--- a/tests/rules/test_state.py
+++ b/tests/rules/test_state.py
@@ -1,6 +1,10 @@
 import pytest
 
-from mex.common.models import ContactPointRuleSetResponse, ExtractedContactPoint
+from mex.common.models import (
+    MEX_PRIMARY_SOURCE_STABLE_TARGET_ID,
+    ContactPointRuleSetResponse,
+    ExtractedContactPoint,
+)
 from mex.common.types import MergedPrimarySourceIdentifier
 from mex.editor.models import EditorValue
 from mex.editor.rules.models import EditorPrimarySource, InputConfig
@@ -41,10 +45,10 @@ def test_state_get_primary_sources_by_field_name() -> None:
         ),
         EditorPrimarySource(
             name=EditorValue(
-                identifier="00000000000000",
-                href="/item/00000000000000",
+                identifier=MEX_PRIMARY_SOURCE_STABLE_TARGET_ID,
+                href="/item/{MEX_PRIMARY_SOURCE_STABLE_TARGET_ID}",
             ),
-            identifier=MergedPrimarySourceIdentifier("00000000000000"),
+            identifier=MEX_PRIMARY_SOURCE_STABLE_TARGET_ID,
             input_config=InputConfig(editable_text=True, allow_additive=True),
             editor_values=[],
             enabled=True,

--- a/tests/rules/test_transform.py
+++ b/tests/rules/test_transform.py
@@ -5,6 +5,7 @@ from pydantic import ValidationError
 
 from mex.common.fields import MERGEABLE_FIELDS_BY_CLASS_NAME
 from mex.common.models import (
+    MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID,
     MEX_PRIMARY_SOURCE_STABLE_TARGET_ID,
     AdditiveActivity,
     AdditiveContactPoint,
@@ -93,7 +94,7 @@ from mex.editor.rules.transform import (
             AdditiveContactPoint(
                 email="example@rki.de",
             ),
-            MEX_PRIMARY_SOURCE_STABLE_TARGET_ID,
+            MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID,
         ),
     ],
 )
@@ -523,14 +524,14 @@ def test_transform_models_to_fields() -> None:
             {
                 "name": {
                     "text": None,
-                    "identifier": "00000000000000",
+                    "identifier": f"{MEX_PRIMARY_SOURCE_STABLE_TARGET_ID}",
                     "badge": None,
                     "being_edited": False,
-                    "href": "/item/00000000000000",
+                    "href": f"/item/{MEX_PRIMARY_SOURCE_STABLE_TARGET_ID}",
                     "external": False,
                     "enabled": True,
                 },
-                "identifier": "00000000000000",
+                "identifier": f"{MEX_PRIMARY_SOURCE_STABLE_TARGET_ID}",
                 "input_config": {
                     "badge_default": None,
                     "badge_options": [],
@@ -548,14 +549,14 @@ def test_transform_models_to_fields() -> None:
             {
                 "name": {
                     "text": None,
-                    "identifier": "00000000000000",
+                    "identifier": f"{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}",
                     "badge": None,
                     "being_edited": False,
-                    "href": "/item/00000000000000",
+                    "href": f"/item/{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}",
                     "external": False,
                     "enabled": True,
                 },
-                "identifier": "00000000000000",
+                "identifier": f"{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}",
                 "input_config": {
                     "badge_default": None,
                     "badge_options": [],
@@ -590,14 +591,14 @@ def test_transform_models_to_fields() -> None:
             {
                 "name": {
                     "text": None,
-                    "identifier": "00000000000000",
+                    "identifier": f"{MEX_PRIMARY_SOURCE_STABLE_TARGET_ID}",
                     "badge": None,
                     "being_edited": False,
-                    "href": "/item/00000000000000",
+                    "href": f"/item/{MEX_PRIMARY_SOURCE_STABLE_TARGET_ID}",
                     "external": False,
                     "enabled": True,
                 },
-                "identifier": "00000000000000",
+                "identifier": f"{MEX_PRIMARY_SOURCE_STABLE_TARGET_ID}",
                 "input_config": {
                     "badge_default": None,
                     "badge_options": [],
@@ -615,14 +616,14 @@ def test_transform_models_to_fields() -> None:
             {
                 "name": {
                     "text": None,
-                    "identifier": "00000000000000",
+                    "identifier": f"{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}",
                     "badge": None,
                     "being_edited": False,
-                    "href": "/item/00000000000000",
+                    "href": f"/item/{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}",
                     "external": False,
                     "enabled": True,
                 },
-                "identifier": "00000000000000",
+                "identifier": f"{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}",
                 "input_config": {
                     "badge_default": None,
                     "badge_options": [],
@@ -635,7 +636,7 @@ def test_transform_models_to_fields() -> None:
                     "render_textarea": False,
                 },
                 "editor_values": [],
-                "enabled": False,
+                "enabled": True,
             },
         ],
     }

--- a/tests/rules/test_transform.py
+++ b/tests/rules/test_transform.py
@@ -672,7 +672,7 @@ def test_transform_models_to_fields() -> None:
                         enabled=True,
                         input_config=InputConfig(editable_text=True),
                         name=EditorValue(text="PS2"),
-                        identifier=MEX_PRIMARY_SOURCE_STABLE_TARGET_ID,
+                        identifier=MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID,
                         editor_values=[
                             EditorValue(text="Duplicate"),
                             EditorValue(text="Duplicate"),
@@ -967,7 +967,7 @@ def test_transform_fields_to_rule_set() -> None:
                     ),
                     EditorPrimarySource(
                         name=EditorValue(text="Primary Source 3"),
-                        identifier=MEX_PRIMARY_SOURCE_STABLE_TARGET_ID,
+                        identifier=MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID,
                         editor_values=[
                             EditorValue(text="SomeName", enabled=True),
                         ],

--- a/tests/rules/test_transform.py
+++ b/tests/rules/test_transform.py
@@ -549,14 +549,14 @@ def test_transform_models_to_fields() -> None:
             {
                 "name": {
                     "text": None,
-                    "identifier": f"{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}",
+                    "identifier": MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID,
                     "badge": None,
                     "being_edited": False,
                     "href": f"/item/{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}",
                     "external": False,
                     "enabled": True,
                 },
-                "identifier": f"{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}",
+                "identifier": MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID,
                 "input_config": {
                     "badge_default": None,
                     "badge_options": [],
@@ -616,14 +616,14 @@ def test_transform_models_to_fields() -> None:
             {
                 "name": {
                     "text": None,
-                    "identifier": f"{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}",
+                    "identifier": MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID,
                     "badge": None,
                     "being_edited": False,
                     "href": f"/item/{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}",
                     "external": False,
                     "enabled": True,
                 },
-                "identifier": f"{MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID}",
+                "identifier": MEX_EDITOR_PRIMARY_SOURCE_STABLE_TARGET_ID,
                 "input_config": {
                     "badge_default": None,
                     "badge_options": [],

--- a/tests/search/test_main.py
+++ b/tests/search/test_main.py
@@ -219,7 +219,7 @@ def test_load_search_params(
     # check primary sources are loaded from url
     primary_sources = page.get_by_test_id("primary-source-filter")
     unchecked = primary_sources.get_by_role("checkbox", checked=False)
-    expect(unchecked).to_have_count(2)
+    expect(unchecked).to_have_count(3)
     checked = primary_sources.get_by_role("checkbox", checked=True)
     expect(checked).to_have_count(1)
 


### PR DESCRIPTION
### Changed

- change primary source of rules from mex to mex-editor
- moved pytest rerun config from toml to makefile

### Fixed

- fixed settings logging on startup and in tests
