### PR TITLE
feature/mx-2213-consent-assets-setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- make consent markdown path configurable via `MEX_EDITOR_ASSETS_DIR`
+
 ### Deprecated
 
 ### Removed

--- a/mex/editor/consent/state.py
+++ b/mex/editor/consent/state.py
@@ -1,6 +1,5 @@
 from collections.abc import Generator
 from datetime import datetime
-from pathlib import Path
 from zoneinfo import ZoneInfo
 
 import reflex as rx
@@ -23,6 +22,7 @@ from mex.editor.exceptions import escalate_error
 from mex.editor.label_var import label_var
 from mex.editor.models import NavItem, SearchResult
 from mex.editor.search.transform import transform_models_to_results
+from mex.editor.settings import EditorSettings
 from mex.editor.state import State
 
 
@@ -57,9 +57,9 @@ class ConsentState(State):
         Returns:
             The translated consent markdown.
         """
-        return Path(f"assets/consent_{self.current_locale}.md").read_text(
-            encoding="utf-8"
-        )
+        settings = EditorSettings.get()
+        path = settings.editor_assets_dir / f"consent_{self.current_locale}.md"
+        return path.read_text(encoding="utf-8")
 
     @rx.var(cache=False)
     def consent_datetime(self) -> str:

--- a/mex/editor/settings.py
+++ b/mex/editor/settings.py
@@ -1,6 +1,7 @@
 from pydantic import Field
 
 from mex.common.settings import BaseSettings
+from mex.common.types import AssetsPath
 from mex.editor.types import EditorUserDatabase
 
 
@@ -37,4 +38,9 @@ class EditorSettings(BaseSettings):
         EditorUserDatabase(),
         description="Database of users.",
         validation_alias="MEX_BACKEND_API_USER_DATABASE",
+    )
+    editor_assets_dir: AssetsPath = Field(
+        AssetsPath(""),
+        description="Editor-specific assets directory, e.g. for consent markdowns.",
+        validation_alias="MEX_EDITOR_ASSETS_DIR",
     )


### PR DESCRIPTION
### Changes

- make consent markdown path configurable via `MEX_EDITOR_ASSETS_DIR`