### PR TITLE
feature/mx-2214-edit-pen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- edit_button is always visible for additives
+
 ### Deprecated
 
 ### Removed

--- a/mex/editor/rules/main.py
+++ b/mex/editor/rules/main.py
@@ -107,10 +107,7 @@ def editor_additive_value(
                 ),
                 render_value(value),
             ),
-            rx.cond(
-                primary_source.input_config.editable_identifier,
-                editor_edit_button(field_name, primary_source, value, index),
-            ),
+            editor_edit_button(field_name, primary_source, value, index),
             width="100%",
         ),
         remove_additive_button(

--- a/tests/create/test_main.py
+++ b/tests/create/test_main.py
@@ -146,6 +146,10 @@ def test_create_page_submit_item(create_page: Page) -> None:
 
     submit_button = page.get_by_test_id("submit-button")
     submit_button.click()
+    page.wait_for_timeout(30_000)
+    page.screenshot(
+        path="tests_create_test_main-test_edit_page_save_item_input_submit_pressed.png"
+    )
 
     toast = page.locator(".editor-toast").first
     expect(toast).to_be_visible()


### PR DESCRIPTION
### Changes
- edit_button is always visible for additives
