### PR TITLE
hotfix/mx-2215-description-single-line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- Text is truncated/wraped based on model.yaml (edit with textarea -> wrap; otherwise truncate)
+- Layout mostly flexing now (Flexlayout)
+
 ### Deprecated
 
 ### Removed

--- a/mex/editor/components.py
+++ b/mex/editor/components.py
@@ -6,13 +6,16 @@ from mex.editor.models import EditorValue
 from mex.editor.state import State
 
 
-def render_value(value: EditorValue) -> rx.Component:
+def render_value(
+    value: EditorValue,
+    truncate_text: bool | rx.Var[bool] = True,  # noqa: FBT001, FBT002
+) -> rx.Component:
     """Render a single editor value."""
     return rx.hstack(
         rx.cond(
             value.href,
             render_link(value),
-            render_text(value),
+            render_text(value, truncate_text),
         ),
         rx.cond(
             value.badge,
@@ -116,20 +119,26 @@ def render_link(value: EditorValue) -> rx.Component:
     )
 
 
-def render_span(text: str | None) -> rx.Component:
+def render_span(
+    text: str | None,
+    truncate_text: bool | rx.Var[bool] = True,  # noqa: FBT001, FBT002
+) -> rx.Component:
     """Render a generic span with the given text."""
     return rx.text(
         rx.cond(text, text, ""),
         as_="span",
-        class_name="truncate",
+        class_name=rx.cond(truncate_text, "truncate", ""),
         title=rx.cond(text, text, ""),
     )
 
 
-def render_text(value: EditorValue) -> rx.Component:
+def render_text(
+    value: EditorValue,
+    truncate_text: bool | rx.Var[bool] = True,  # noqa: FBT001, FBT002
+) -> rx.Component:
     """Render an editor value as a text span."""
     return rx.skeleton(
-        render_span(value.text),
+        render_span(value.text, truncate_text),
         min_width="16ch",
         min_height="1lh",
         loading=rx.cond(value.text, False, True),  # noqa: FBT003

--- a/mex/editor/edit/main.py
+++ b/mex/editor/edit/main.py
@@ -3,13 +3,19 @@ import reflex as rx
 from mex.editor.components import render_value
 from mex.editor.edit.state import EditState
 from mex.editor.layout import page
-from mex.editor.rules.main import editor_field, rule_page_header, validation_errors
+from mex.editor.rules.main import (
+    editor_field,
+    flex1_col_style,
+    rule_page_header,
+    validation_errors,
+)
 from mex.editor.rules.state import RuleState
 from mex.editor.search_results_component import (
     SearchResultsListItemOptions,
     SearchResultsListOptions,
     search_results_list,
 )
+from mex.editor.style_helper import flex3_style
 
 
 def edit_title() -> rx.Component:
@@ -114,7 +120,7 @@ def superseding_by_backward_card() -> rx.Component:
     return rx.hstack(
         rx.card(
             rx.text(EditState.label_field_superseded_by_label),
-            style=rx.Style(width="25%"),
+            style=flex1_col_style,
             custom_attrs={"data-testid": "field-supersededBy-backward-name"},
             title=EditState.label_field_superseded_by_description,
         ),
@@ -131,11 +137,7 @@ def superseding_by_backward_card() -> rx.Component:
                 ),
                 rx.text(EditState.label_field_superseded_by_empty),
             ),
-            style=rx.Style(width="100%"),
-        ),
-        style=rx.Style(
-            width="100%",
-            margin="var(--space-3) 0",
+            style=flex3_style,
         ),
         custom_attrs={"data-testid": "field-supersededBy-backward"},
     )
@@ -166,9 +168,9 @@ def index() -> rx.Component:
             ),
             superseding_by_backward_card(),
             validation_errors(),
+            align="stretch",
             style=rx.Style(
-                width="100%",
-                marginTop="calc(2 * var(--space-6))",
+                flex="1", marginTop="calc(2 * var(--space-6))", overflow="auto"
             ),
         ),
     )

--- a/mex/editor/rules/main.py
+++ b/mex/editor/rules/main.py
@@ -13,8 +13,16 @@ from mex.editor.rules.models import (
 )
 from mex.editor.rules.state import RuleState
 from mex.editor.search_reference_dialog import search_reference_dialog
+from mex.editor.style_helper import (
+    add_component_style,
+    add_flex1,
+    flex1_style,
+    flex3_style,
+)
 
 locale_service = LocaleService.get()
+
+flex1_col_style = flex1_style | {"max_width": "25%"}
 
 
 def editor_value_switch(
@@ -77,13 +85,17 @@ def editor_static_value(
 ) -> rx.Component:
     """Render a static value with an optional subtractive rule switch."""
     return rx.hstack(
-        render_value(value),
+        render_value(
+            value,
+            rx.cond(primary_source.input_config.render_textarea, False, True),  # noqa: FBT003
+        ),
         editor_value_switch(
             field_name,
             primary_source,
             value,
             index,
         ),
+        style=flex1_style,
     )
 
 
@@ -99,19 +111,30 @@ def editor_additive_value(
         rx.hstack(
             rx.cond(
                 value.being_edited,
-                additive_rule_input(
-                    field_translation,
-                    primary_source.input_config,
-                    index,
-                    value,
+                add_flex1(
+                    additive_rule_input(
+                        field_translation,
+                        primary_source.input_config,
+                        index,
+                        value,
+                    )
                 ),
-                render_value(value),
+                add_flex1(
+                    render_value(
+                        value,
+                        rx.cond(
+                            primary_source.input_config.render_textarea,
+                            False,  # noqa: FBT003
+                            True,  # noqa: FBT003
+                        ),
+                    )
+                ),
             ),
             rx.cond(
                 primary_source.input_config.editable_identifier,
                 editor_edit_button(field_name, primary_source, value, index),
             ),
-            width="100%",
+            style=flex1_style,
         ),
         remove_additive_button(
             field_translation,
@@ -119,7 +142,7 @@ def editor_additive_value(
         ),
         custom_attrs={"data-testid": f"additive-rule-{field_name}-{index}"},
         spacing="8",
-        width="100%",
+        style=flex1_style,
     )
 
 
@@ -218,7 +241,6 @@ def identifier_input(
             style=rx.Style(
                 margin="calc(-1 * var(--space-1))",
                 width="100%",
-                flex="1",
             ),
             custom_attrs={
                 "data-testid": f"additive-rule-{field.name}-{index}-identifier"
@@ -231,7 +253,6 @@ def identifier_input(
             reference_types=field_translation.field.value_type,
             field_label=field_translation.label,
         ),
-        style=rx.Style(flex="1"),
     )
 
 
@@ -279,25 +300,24 @@ def additive_rule_input(
     return rx.hstack(
         rx.cond(
             input_config.editable_href,
-            href_input(field.name, index, value.href),
+            add_flex1(href_input(field.name, index, value.href)),
         ),
         rx.cond(
             input_config.editable_text,
             rx.cond(
                 input_config.render_textarea,
-                textarea_input(field.name, index, value.text),
-                text_input(field.name, index, value.text),
+                add_flex1(textarea_input(field.name, index, value.text)),
+                add_flex1(text_input(field.name, index, value.text)),
             ),
         ),
         rx.cond(
             input_config.editable_identifier,
-            identifier_input(field_translation, index, value.identifier),
+            add_flex1(identifier_input(field_translation, index, value.identifier)),
         ),
         rx.cond(
             input_config.editable_badge,
-            badge_input(field.name, index, input_config, value.badge),
+            add_flex1(badge_input(field.name, index, input_config, value.badge)),
         ),
-        width="100%",
     )
 
 
@@ -328,7 +348,6 @@ def editor_value_card(
         background=rx.cond(
             primary_source.enabled & value.enabled, "inherit", "var(--gray-a4)"
         ),
-        style=rx.Style(width="100%"),
         custom_attrs={
             "data-testid": f"value-{field_name}-{primary_source.identifier}-{index}"
         },
@@ -360,7 +379,7 @@ def primary_source_name(
     """Return the name of a primary source as a card with a preventive rule toggle."""
     return rx.card(
         rx.hstack(
-            render_value(primary_source.name),
+            add_flex1(render_value(primary_source.name)),
             rx.spacer(),
             rx.cond(
                 ~cast("rx.vars.BooleanVar", primary_source.input_config.allow_additive),
@@ -369,10 +388,8 @@ def primary_source_name(
                     primary_source,
                 ),
             ),
-            wrap="wrap",
         ),
         background=rx.cond(primary_source.enabled, "inherit", "var(--gray-a4)"),
-        style=rx.Style(width="33%"),
         custom_attrs={
             "data-testid": (
                 f"primary-source-{field_name}-{primary_source.identifier}-name"
@@ -404,7 +421,6 @@ def new_additive_button(
                 "data-testid": f"new-additive-{field_name}-{primary_source_identifier}"
             },
         ),
-        style=rx.Style(width="100%"),
     )
 
 
@@ -430,7 +446,7 @@ def editor_primary_source_stack(
                 primary_source.identifier,
             ),
         ),
-        style=rx.Style(width="100%"),
+        align="stretch",
     )
 
 
@@ -441,15 +457,17 @@ def editor_primary_source(
     """Return a horizontal grid of cards for editing one primary source."""
     field_name = field_translation.field.name
     return rx.hstack(
-        primary_source_name(
-            field_name,
-            primary_source,
+        add_component_style(
+            primary_source_name(
+                field_name,
+                primary_source,
+            ),
+            flex1_col_style,
         ),
-        editor_primary_source_stack(
-            field_translation,
-            primary_source,
+        add_component_style(
+            editor_primary_source_stack(field_translation, primary_source),
+            flex3_style,
         ),
-        style=rx.Style(width="100%"),
         custom_attrs={
             "data-testid": f"primary-source-{field_name}-{primary_source.identifier}",
         },
@@ -471,18 +489,15 @@ def field_name_card(
             spacing="1",
         ),
         title=field_translation.description,
-        style=rx.Style(width="25%"),
         custom_attrs={"data-testid": f"field-{field.name}-name"},
     )
 
 
-def editor_field(
-    field_translation: FieldTranslation,
-) -> rx.Component:
+def editor_field(field_translation: FieldTranslation) -> rx.Component:
     """Return a horizontal grid of cards for editing one field."""
     field = field_translation.field
     return rx.hstack(
-        field_name_card(field_translation),
+        add_component_style(field_name_card(field_translation), flex1_col_style),
         rx.vstack(
             rx.foreach(
                 field.primary_sources,
@@ -490,12 +505,10 @@ def editor_field(
                     field_translation, primary_source
                 ),
             ),
-            style=rx.Style(width="100%"),
+            align="stretch",
+            style=flex3_style,
         ),
-        style=rx.Style(
-            width="100%",
-            margin="var(--space-3) 0",
-        ),
+        style=rx.Style(margin="var(--space-3) 0"),
         custom_attrs={"data-testid": f"field-{field.name}"},
         role="row",
     )

--- a/mex/editor/style_helper.py
+++ b/mex/editor/style_helper.py
@@ -1,0 +1,23 @@
+from typing import Any
+
+import reflex as rx
+
+flex1_style = rx.Style(flex="1", min_height="0", min_width="0")
+flex3_style = rx.Style(flex="3", min_height="0", min_width="0")
+
+
+def add_component_style(
+    component: rx.Component, style: rx.Style | dict[str, Any]
+) -> rx.Component:
+    """Add specified style to given component and returns the styled component.
+
+    If the component already has a style the styles are merged, where the given `style`
+    arg will override existing keys.
+    """
+    component.style = rx.Style(component.style | style)
+    return component
+
+
+def add_flex1(component: rx.Component) -> rx.Component:
+    """Add flex1 style to the given component and returns it."""
+    return add_component_style(component, flex1_style)


### PR DESCRIPTION
### PR Context
Since there was no real AC i was a bit creative and decided that ill wrap text fields (instead of truncating them) that are configured to render as textarea in edit mode. I also reworked the layout using flex only.

### Changes
- Text rendering for textarea/-box fields
- Layout cleanup -> flex it