### PR TITLE
feature/mx-2213 consent site wrap up pt. 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - added into InputConfig allow_subtractive and allow_preventive
 
 ### Changes
+- use merged items endpoint for consent site search
 - adpdated tests because identifierInPrimarySource is not in MERGEABLE_FIELDS
 
 - Updated uv to 0.10.9

--- a/mex/editor/consent/consent_category_list.py
+++ b/mex/editor/consent/consent_category_list.py
@@ -7,7 +7,7 @@ from reflex.event import EventSpec
 from requests import HTTPError
 
 from mex.common.backend_api.connector import BackendApiConnector
-from mex.common.models import AnyPreviewModel
+from mex.common.models import AnyMergedModel
 from mex.editor.component_option_helper import build_pagination_options
 from mex.editor.consent.state import ConsentState
 from mex.editor.consent.transform import add_external_links_to_results
@@ -60,13 +60,13 @@ class ConsentCategoryList(rx.ComponentState, PaginationStateMixin):
         self.is_loading = True
         yield None
 
-        all_results: list[AnyPreviewModel] = []
+        all_results: list[AnyMergedModel] = []
         total = 0
 
         try:
             for ref_field in self.config.reference_fields:
                 # TODO(FE): use advanced search method to fetch for multiple refs
-                response = connector.fetch_preview_items(
+                response = connector.fetch_merged_items(
                     query_string=None,
                     entity_type=[self.config.entity_type],
                     skip=self.skip,

--- a/mex/editor/consent/state.py
+++ b/mex/editor/consent/state.py
@@ -69,7 +69,7 @@ class ConsentState(State):
         timestamp_str = self.consent_status.title[0].text
         timestamp_dt = datetime.fromisoformat(str(timestamp_str))
         timestamp_local = timestamp_dt.astimezone(ZoneInfo("Europe/Berlin"))
-        return timestamp_local.strftime("%d.%m.%Y um %H:%M")
+        return timestamp_local.strftime("%d.%m.%Y %H:%M")
 
     @rx.event
     def get_consent(self) -> Generator[EventSpec | None]:


### PR DESCRIPTION
### PR Context
<!-- Additional info for the reviewer -->
- the AssetsPath setup for the consent markdown and removal of search-results-summary is already done

### Changes
<!-- Changes in existing functionality -->
- use merged items endpoint instead of preview endpoint
- fixed timestamp to be translation friendly
