### PR TITLE
Bump cookiecutter template to af9ddc

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "43f7153cb6e402a939c4054b9b72999788ba70c1",
+  "commit": "af9ddce126397e3b56a29be097449b22199dcecd",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -8,7 +8,7 @@
       "short_summary": "Metadata editor web application.",
       "long_summary": "The `mex-editor` is a browser application that allows creating and editing rules to non-destructively manipulate metadata. This can be used to enrich data with manual input or insert new data from scratch.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "43f7153cb6e402a939c4054b9b72999788ba70c1"
+      "_commit": "af9ddce126397e3b56a29be097449b22199dcecd"
     }
   },
   "directory": null

--- a/.dockerignore
+++ b/.dockerignore
@@ -113,6 +113,19 @@ dmypy.json
 .history/
 *.code-workspace
 
+# Node and Angular
+.angular/
+.nodeenv
+.sass-cache/
+connect.lock
+coverage
+libpeerconnection.log
+node_modules
+npm-debug.log
+out-tsc
+testem.log
+typings
+
 # SQLite databases
 *.db
 

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@ downloads/
 eggs/
 lib/
 lib64/
-locked-requirements.txt
 MANIFEST
 parts/
 sdist/
@@ -112,8 +111,25 @@ dmypy.json
 
 # VisualStudioCode
 .vscode/*
+!.vscode/extensions.json
+!.vscode/launch.json
+!.vscode/settings.json
+!.vscode/tasks.json
 .history/
 *.code-workspace
+
+# Node and Angular
+.angular/
+.nodeenv
+.sass-cache/
+connect.lock
+coverage
+libpeerconnection.log
+node_modules
+npm-debug.log
+out-tsc
+testem.log
+typings
 
 # SQLite databases
 *.db

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,13 @@
 fail_fast: false
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.8
+    rev: v0.15.10
     hooks:
       - id: ruff-check
+        name: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
+        name: ruff-format
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
@@ -23,7 +25,7 @@ repos:
       - id: fix-byte-order-marker
         name: byte-order
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.2
+    rev: 0.11.7
     hooks:
       - id: uv-lock
         name: uv
@@ -33,7 +35,7 @@ repos:
     - id: mypy
       name: mypy
       entry: uv run dmypy run --timeout 7200 -- mex tests
-      files: ^(mex|tests)/
+      files: ^(mex|tests)/|pyproject\.toml$
       language: system
       pass_filenames: false
       types: [python]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- updated template to https://github.com/robert-koch-institut/mex-template/commit/af9ddc
+
 ### Deprecated
 
 ### Removed


### PR DESCRIPTION
### Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/af9ddc

### Conflicts

```diff
diff a/.github/workflows/release.yml b/.github/workflows/release.yml	(rejected hunks)
@@ -94,28 +94,6 @@ jobs:
           ref: ${{ needs.release.outputs.tag }}
           persist-credentials: false
 
-      - name: Cache requirements
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        env:
-          cache-name: cache-requirements
-        with:
-          path: ~/.cache/pip
-          key: ${{ env.cache-name }}-${{ hashFiles('requirements.txt') }}
-          restore-keys: |
-            ${{ env.cache-name }}-
-
-      - name: Setup python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: 3.14
-
-      - name: Install requirements
-        run: make setup
-
-      - name: Generate locked requirements.txt
-        run: |
-          uv export --no-dev --output locked-requirements.txt --no-hashes
-
       - name: Login to container registry
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
```

```diff
diff a/.github/workflows/cve-scan.yml b/.github/workflows/cve-scan.yml	(rejected hunks)
@@ -59,11 +59,6 @@ jobs:
       - name: Install requirements
         run: make setup
 
-      - name: Export dependencies
-        run: |
-          mkdir --parents uv
-          uv export --no-hashes --format requirements-txt --output-file uv/requirements.txt
-
       - name: Run trivy
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
```

```diff
diff a/Dockerfile b/Dockerfile	(rejected hunks)
@@ -1,6 +1,20 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3.14 AS base
+FROM python:3.14 AS builder
+
+WORKDIR /build
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=on
+ENV PIP_NO_INPUT=on
+ENV PIP_PREFER_BINARY=on
+ENV PIP_PROGRESS_BAR=off
+
+COPY . .
+
+RUN pip install --no-cache-dir -r requirements.txt
+RUN uv export --no-dev --no-editable | uv pip install --system --no-deps -r -
+
+FROM python:3.14-slim
 
 LABEL org.opencontainers.image.authors="mex@rki.de"
 LABEL org.opencontainers.image.description="Metadata editor web application."
@@ -11,28 +25,14 @@ LABEL org.opencontainers.image.vendor="robert-koch-institut"
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONOPTIMIZE=1
 
-ENV PIP_DISABLE_PIP_VERSION_CHECK=on
-ENV PIP_NO_INPUT=on
-ENV PIP_PREFER_BINARY=on
-ENV PIP_PROGRESS_BAR=off
-
 ENV MEX_EDITOR_HOST=0.0.0.0
 
 WORKDIR /app
 
-RUN adduser \
-    --disabled-password \
-    --gecos "" \
-    --shell "/sbin/nologin" \
-    --no-create-home \
-    --uid "10001" \
-    mex
-
-COPY . .
-
-RUN --mount=type=cache,target=/root/.cache/pip pip install -r locked-requirements.txt --no-deps
+COPY --from=builder /usr/local/lib/python3.14/site-packages /usr/local/lib/python3.14/site-packages
+COPY --from=builder /usr/local/bin/editor /usr/local/bin/editor
 
-USER mex
+USER 10001
 
 EXPOSE 8080
 
```

```diff
diff a/compose.yaml b/compose.yaml	(rejected hunks)
@@ -3,12 +3,9 @@ services:
     build:
       context: .
     ports:
-      - 8081:8081
+      - 8080:8080
     environment:
       - MEX_EDITOR_HOST=0.0.0.0
-      - MEX_EDITOR_PORT=8080
-    expose:
-      - 8081
     healthcheck:
       test: [ "CMD", "curl", "http://0.0.0.0:8080/_system/check" ]
       interval: 60s
```

```diff
diff a/Makefile b/Makefile	(rejected hunks)
@@ -43,7 +43,6 @@ wheel:
 image:
 	# build the docker image
 	@ echo building docker image mex-editor:${LATEST}; \
-	export DOCKER_BUILDKIT=1; \
 	docker build \
 		--tag rki/mex-editor:${LATEST} \
 		--tag rki/mex-editor:latest .; \
@@ -53,15 +52,13 @@ run: image
 	@ echo running docker container mex-editor:${LATEST}; \
 	docker run \
 		--env MEX_EDITOR_HOST=0.0.0.0 \
-		--publish 8081:8081 \
+		--publish 8080:8080 \
 		rki/mex-editor:${LATEST}; \
 
-start: image
+start:
 	# start the service using docker compose
 	@ echo start mex-editor:${LATEST} with compose; \
-	export DOCKER_BUILDKIT=1; \
-	export COMPOSE_DOCKER_CLI_BUILD=1; \
-	docker compose up --remove-orphans; \
+	docker compose up --build --remove-orphans; \
 
 docs:
 	# use sphinx to auto-generate html docs from code
```

```diff
diff a/requirements.txt b/requirements.txt	(rejected hunks)
@@ -1,4 +1,4 @@
 cruft==2.16.0
-mex-release==1.3.2
-uv==0.11.2
+mex-release==1.3.3
+uv==0.11.7
 pre-commit==4.5.1
```
