### PR TITLE
Bump cookiecutter template to 26afa8

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "dd987e6cc7f1bcb7298b4e7aecd5055de15458bb",
+  "commit": "26afa85ef969fa8385019c932f32d6b7b452b142",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -8,7 +8,7 @@
       "short_summary": "Metadata editor web application.",
       "long_summary": "The `mex-editor` is a browser application that allows creating and editing rules to non-destructively manipulate metadata. This can be used to enrich data with manual input or insert new data from scratch.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "dd987e6cc7f1bcb7298b4e7aecd5055de15458bb"
+      "_commit": "26afa85ef969fa8385019c932f32d6b7b452b142"
     }
   },
   "directory": null

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write  # Required for cosign signing
 
     steps:
       - name: Checkout repo
@@ -102,15 +103,29 @@ jobs:
           password: ${{secrets.GITHUB_TOKEN}}
 
       - name: Build, tag and push docker image
+        id: push_step
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v.7.1.0
         env:
           IMAGE: ghcr.io/${{ github.repository }}
           TAG: ${{ needs.release.outputs.tag }}
+        with:
+          push: true
+          tags: |
+            ${IMAGE}:latest
+            ${IMAGE}:${{ github.sha }}
+            ${IMAGE}:${TAG}
+          outputs: type=image,oci-mediatypes=true
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: 'v2.4.1'
+
+      - name: Sign Docker image keyless
+        env:
+          IMAGE: ghcr.io/${{ github.repository }}@${{ steps.push_step.outputs.digest }}
         run: |
-          docker build . \
-          --tag ${IMAGE}:latest \
-          --tag ${IMAGE}:${{ github.sha }} \
-          --tag ${IMAGE}:${TAG}
-          docker push --all-tags ${IMAGE}
+          cosign sign --yes "$IMAGE"
 
   distribute:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- updated template to https://github.com/robert-koch-institut/mex-template/commit/26afa8
+
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/dd987e
 
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -91,6 +91,13 @@ components of the MEx project are open-sourced under the same license as well.
 - run directly using docker `make run`
 - start with docker compose `make start`
 
+### Container verification
+
+Images released to GHCR are signed using [cosign](https://github.com/sigstore/cosign).
+
+To verify an image manually:
+`cosign verify --certificate-identity-regexp "https://github.com/robert-koch-institut/editor" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" ghcr.io/robert-koch-institut/editor:<tag>`
+
 ## Commands
 
 - run `uv run {command} --help` to print instructions


### PR DESCRIPTION
### Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/26afa8
