### PR TITLE
Bump cookiecutter template to 1d816d

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "5c0569f9f52ff356e9ebfd48119ede41bc47a8a1",
+  "commit": "1d816db77df20388022165cab12f45821d0b9f6d",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -8,7 +8,7 @@
       "short_summary": "Metadata editor web application.",
       "long_summary": "The `mex-editor` is a browser application that allows creating and editing rules to non-destructively manipulate metadata. This can be used to enrich data with manual input or insert new data from scratch.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "5c0569f9f52ff356e9ebfd48119ede41bc47a8a1"
+      "_commit": "1d816db77df20388022165cab12f45821d0b9f6d"
     }
   },
   "directory": null

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write  # Required for cosign signing
 
     steps:
       - name: Checkout repo
@@ -120,30 +121,11 @@ jobs:
         with:
           cosign-release: 'v2.4.1'
 
-      - name: Sign docker images
+      - name: Sign Docker image keyless
         env:
-          IMAGE: ghcr.io/${{ github.repository }}
-          DIGEST: ${{ steps.push_step.outputs.digest }}
-          BASE64_PRIV_KEY: ${{ secrets.MEX_SIGNING_KEY }}
-          COSIGN_PASSWORD: ""
-          BASE64_PUB_KEY: ${{ vars.MEX_SIGNING_PUB }}
-          COSIGN_DOCKER_MEDIA_TYPES: 1
+          IMAGE: ghcr.io/${{ github.repository }}@${{ steps.push_step.outputs.digest }}
         run: |
-          set -e # exit on first error
-
-          # signing
-          echo "Signing Image: ${IMAGE}@${DIGEST}"
-          export COSIGN_PRIVATE_KEY=$(echo "$BASE64_PRIV_KEY" | base64 --decode)
-          cosign sign --yes --registry-referrers-mode=legacy --key env://COSIGN_PRIVATE_KEY ${IMAGE}@${DIGEST}
-          echo "Signature generated successfully"
-
-          # smoke test
-          echo "Verifying signature"
-          trap 'rm -f temp_ssh_id.pub cosign.pub' EXIT
-          echo "$BASE64_PUB_KEY" | base64 --decode > temp_ssh_id.pub
-          ssh-keygen -e -m PKCS8 -f temp_ssh_id.pub > cosign.pub
-          cosign verify --key cosign.pub "${IMAGE}@${DIGEST}"
-          echo "Signature verified successfully"
+          cosign sign --yes "$IMAGE"
 
   distribute:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- updated template to https://github.com/robert-koch-institut/mex-template/commit/1d816d
+
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/5c0569
 
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/dd987e

--- a/README.md
+++ b/README.md
@@ -95,18 +95,8 @@ components of the MEx project are open-sourced under the same license as well.
 
 Images released to GHCR are signed using [cosign](https://github.com/sigstore/cosign).
 
-Verification is handled by our deployment using the organization's public key.
 To verify an image manually:
-1. install `cosign` on your system
-2. obtain the organization's public key
-3. run the following command:
-   ```bash
-   cosign verify --key cosign.pub ghcr.io/robert-koch-institut/mex-editor:<TAG>
-   ```
-
-To set up signing for a new project:
-1. ensure the organization-wide private key is available in a GitHub Secret named `MEX_SIGNING_KEY`
-2. ensure the organization-wide public key is available in a GitHub Variable named `MEX_SIGNING_PUB`
+`cosign verify --certificate-identity-regexp "https://github.com/robert-koch-institut/editor" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" ghcr.io/robert-koch-institut/editor:<tag>`
 
 ## Commands
 

--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,7 @@
     "lockFileMaintenance": {
         "enabled": true,
         "schedule": [
-            "before 4am on monday"
+            "on monday"
         ]
     },
     "packageRules": [
@@ -38,7 +38,30 @@
             "pinDigests": true
         },
         {
-            "description": "Immediately apply updates of mex packages",
+            "description": "Group all GitHub Actions updates into a single PR",
+            "groupName": "github-actions",
+            "matchManagers": [
+                "github-actions"
+            ]
+        },
+        {
+            "description": "Group all non-major Python updates into a single PR",
+            "groupName": "python non-major",
+            "matchCurrentVersion": "!/^0/",
+            "matchManagers": [
+                "pep621",
+                "pip_requirements"
+            ],
+            "matchUpdateTypes": [
+                "minor",
+                "patch",
+                "pin",
+                "digest"
+            ]
+        },
+        {
+            "description": "Immediately apply updates of mex packages in dedicated PR",
+            "groupName": null,
             "matchPackageNames": [
                 "mex-*"
             ],
@@ -46,6 +69,9 @@
         }
     ],
     "prFooter": "",
+    "pre-commit": {
+        "enabled": true
+    },
     "vulnerabilityAlerts": {
         "enabled": true
     }


### PR DESCRIPTION
### Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/1d816d

### Conflicts

```diff
diff a/.github/workflows/cve-scan.yml b/.github/workflows/cve-scan.yml	(rejected hunks)
@@ -32,7 +32,7 @@ jobs:
           fetch-depth: 1
 
       - name: Cache requirements
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         env:
           cache-name: cache-requirements
         with:
@@ -42,7 +42,7 @@ jobs:
             ${{ env.cache-name }}-
 
       - name: Cache environment
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         env:
           cache-name: cache-environment
         with:
```

```diff
diff a/.github/workflows/linting.yml b/.github/workflows/linting.yml	(rejected hunks)
@@ -39,7 +39,7 @@ jobs:
           fetch-depth: 1
 
       - name: Cache requirements
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         env:
           cache-name: cache-requirements
         with:
@@ -49,7 +49,7 @@ jobs:
             ${{ env.cache-name }}-
 
       - name: Cache environment
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         env:
           cache-name: cache-environment
         with:
```

```diff
diff a/.github/workflows/testing.yml b/.github/workflows/testing.yml	(rejected hunks)
@@ -39,7 +39,7 @@ jobs:
           fetch-depth: 1
 
       - name: Cache requirements
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         env:
           cache-name: cache-requirements
         with:
@@ -49,7 +49,7 @@ jobs:
             ${{ env.cache-name }}-
 
       - name: Cache environment
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         env:
           cache-name: cache-environment
         with:
```

```diff
diff a/.github/workflows/cookiecutter.yml b/.github/workflows/cookiecutter.yml	(rejected hunks)
@@ -37,7 +37,7 @@ jobs:
           persist-credentials: false
 
       - name: Cache requirements
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         env:
           cache-name: cache-requirements
         with:
```

```diff
diff a/.github/workflows/release.yml b/.github/workflows/release.yml	(rejected hunks)
@@ -44,7 +44,7 @@ jobs:
           persist-credentials: false
 
       - name: Cache requirements
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         env:
           cache-name: cache-requirements
         with:
@@ -128,7 +143,7 @@ jobs:
           persist-credentials: false
 
       - name: Cache requirements
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         env:
           cache-name: cache-requirements
         with:
```

```diff
diff a/.github/workflows/documentation.yml b/.github/workflows/documentation.yml	(rejected hunks)
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 1
 
       - name: Cache requirements
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         env:
           cache-name: cache-requirements
         with:
@@ -40,7 +40,7 @@ jobs:
             ${{ env.cache-name }}-
 
       - name: Cache environment
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         env:
           cache-name: cache-environment
         with:
```

```diff
diff a/requirements.txt b/requirements.txt	(rejected hunks)
@@ -1,4 +1,4 @@
 cruft==2.16.0
 mex-release==1.3.3
-uv==0.11.8
+uv==0.11.15
 pre-commit==4.6.0
```
