### PR TITLE
Bump cookiecutter template to 11612b

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "52887e07dbc2501edea124e2a27a4f472f970d7e",
+  "commit": "11612bf1151a5d537ecf660e70135c2e9f79d350",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -8,7 +8,7 @@
       "short_summary": "Metadata editor web application.",
       "long_summary": "The `mex-editor` is a browser application that allows creating and editing rules to non-destructively manipulate metadata. This can be used to enrich data with manual input or insert new data from scratch.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "52887e07dbc2501edea124e2a27a4f472f970d7e"
+      "_commit": "11612bf1151a5d537ecf660e70135c2e9f79d350"
     }
   },
   "directory": null

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,9 +111,9 @@ jobs:
         with:
           push: true
           tags: |
-            ${IMAGE}:latest
-            ${IMAGE}:${{ github.sha }}
-            ${IMAGE}:${TAG}
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:${{ github.sha }}
+            ${{ env.IMAGE }}:${{ env.TAG }}
           outputs: type=image,oci-mediatypes=true
 
       - name: Install cosign

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- updated template to https://github.com/robert-koch-institut/mex-template/commit/11612b
+
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/52887e
 
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/1d816d

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ components of the MEx project are open-sourced under the same license as well.
 Images released to GHCR are signed using [cosign](https://github.com/sigstore/cosign).
 
 To verify an image manually:
-`cosign verify --certificate-identity-regexp "https://github.com/robert-koch-institut/editor" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" ghcr.io/robert-koch-institut/editor:<tag>`
+`cosign verify --certificate-identity-regexp "https://github.com/robert-koch-institut/mex-editor/.github/workflows/release.yml@refs/heads/main" --certificate-oidc-issuer "https://token.actions.githubusercontent.com" ghcr.io/robert-koch-institut/mex-editor:<tag>`
 
 ## Commands
 


### PR DESCRIPTION
### Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/11612b
