### PR TITLE
hotfix/consent-submit-test-stop-fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- add timeout to consent test
+- fix consent test submit failing
 - fix cookiecutter permissions
 - fix layout on create page
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- add timeout to consent test
 - fix cookiecutter permissions
 - fix layout on create page
 

--- a/tests/consent/test_main.py
+++ b/tests/consent/test_main.py
@@ -122,21 +122,23 @@ def test_submit_consent(consent_page: Page) -> None:
     # check if denied consent is submitted
     denial_button = page.get_by_test_id("denial-consent-button")
     denial_button.click()
-    page.wait_for_timeout(10_000)
     page.screenshot(path="tests_consent_test_main-test_submit_consent_invalid.png")
     toast = page.locator(".editor-toast").first
     expect(toast).to_be_visible()
     expect(toast).to_have_attribute("data-type", "success")
-    expect(consent_status).to_contain_text(f"Sie haben Ihre Ablehnung am {today}")
+    expect(page.get_by_test_id("consent-status")).to_contain_text(
+        f"Sie haben Ihre Ablehnung am {today}"
+    )
 
     # check if given consent is submitted
     page.get_by_test_id("accept-consent-button").click()
-    page.wait_for_timeout(10_000)
     page.screenshot(path="tests_consent_test_main-test_submit_consent_valid.png")
     toast = page.locator(".editor-toast").first
     expect(toast).to_be_visible()
     expect(toast).to_have_attribute("data-type", "success")
-    expect(consent_status).to_contain_text(f"Sie haben Ihre Einwilligung am {today}")
+    expect(page.get_by_test_id("consent-status")).to_contain_text(
+        f"Sie haben Ihre Einwilligung am {today}"
+    )
 
     # check if denial button is disabled after positive consent
     expect(denial_button).to_be_disabled()

--- a/tests/consent/test_main.py
+++ b/tests/consent/test_main.py
@@ -122,6 +122,7 @@ def test_submit_consent(consent_page: Page) -> None:
     # check if denied consent is submitted
     denial_button = page.get_by_test_id("denial-consent-button")
     denial_button.click()
+    page.wait_for_timeout(10_000)
     page.screenshot(path="tests_consent_test_main-test_submit_consent_invalid.png")
     toast = page.locator(".editor-toast").first
     expect(toast).to_be_visible()
@@ -130,6 +131,7 @@ def test_submit_consent(consent_page: Page) -> None:
 
     # check if given consent is submitted
     page.get_by_test_id("accept-consent-button").click()
+    page.wait_for_timeout(10_000)
     page.screenshot(path="tests_consent_test_main-test_submit_consent_valid.png")
     toast = page.locator(".editor-toast").first
     expect(toast).to_be_visible()


### PR DESCRIPTION
### PR Context
I added a timeout and hope the consent test now stops failing.