### PR TITLE
Bump cookiecutter template to 1.4.0

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,14 +1,14 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "192830effd8041fcff795b110a3915093c96c00e",
-  "checkout": "1.3.0",
+  "commit": "c6d13eb329f5a884e4ea9cbdcdb12c3299b9c11c",
+  "checkout": "1.4.0",
   "context": {
     "cookiecutter": {
       "project_name": "admin",
       "short_summary": "Metadata admin web application.",
       "long_summary": "The `mex-admin` is a browser application that allows creating and editing rules to non-destructively manipulate metadata. This can be used to enrich data with manual input or insert new data from scratch.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "192830effd8041fcff795b110a3915093c96c00e"
+      "_commit": "c6d13eb329f5a884e4ea9cbdcdb12c3299b9c11c"
     }
   },
   "directory": null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- new template https://github.com/robert-koch-institut/mex-template/releases/tag/1.4.0
 - use docker-compose for starting services in CI testing
 - run the dev server on ports 8030/8031
 


### PR DESCRIPTION
### Changes

- new template https://github.com/robert-koch-institut/mex-template/releases/tag/1.4.0
